### PR TITLE
🧹 cleanup redundant getattr checks in JudgeAgent

### DIFF
--- a/src/agents/judge.py
+++ b/src/agents/judge.py
@@ -265,21 +265,11 @@ class JudgeAgent(BaseAgent):
                     filters["user_id"] = user_id
                 filters["domain"] = JudgeDomain.PROFILE.value
 
-                search_fn = getattr(self.vector_store, "search_by_metadata", None)
-                if search_fn is not None:
-                    results = search_fn(filters=filters, top_k=self.top_k)
-                    matches[item_str] = results if results else []
-                else:
-                    self.logger.debug(
-                        "Vector store has no search_by_metadata — "
-                        "falling back to semantic search for profile."
-                    )
-                    # Graceful fallback to semantic search
-                    results = await self._search_vector_store(
-                        query_text=item_str,
-                        filters={"user_id": user_id, "domain": "profile"} if user_id else None,
-                    )
-                    matches[item_str] = results
+                results = self.vector_store.search_by_metadata(
+                    filters=filters,
+                    top_k=self.top_k,
+                )
+                matches[item_str] = results if results else []
             except Exception as exc:
                 self.logger.warning(
                     "Profile metadata search failed for '%s': %s",
@@ -300,14 +290,11 @@ class JudgeAgent(BaseAgent):
         if not self.vector_store:
             return []
 
-        search_fn = getattr(self.vector_store, "search_by_text", None)
-        if search_fn is not None:
-            return await search_fn(query_text, top_k=self.top_k, filters=filters)
-
-        self.logger.debug(
-            "Vector store has no search_by_text — skipping search for this item."
+        return await self.vector_store.search_by_text(
+            query_text,
+            top_k=self.top_k,
+            filters=filters,
         )
-        return []
 
     # -- Temporal: Neo4j (graph DB) ----------------------------------------
 

--- a/src/storage/base.py
+++ b/src/storage/base.py
@@ -67,10 +67,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from ..config import get_logger
 from ..utils.exceptions import (
-    VectorStoreError,
-    VectorStoreConnectionError,
     VectorStoreValidationError,
-    VectorNotFoundError,
 )
 
 logger = get_logger(__name__)
@@ -221,6 +218,13 @@ class BaseVectorStore(ABC):
        class MockVectorStore(BaseVectorStore):
            def add(self, ...): return ["mock-id"]
            def search(self, ...): return [SearchResult(...)]
+           def update(self, ...): return True
+           def delete(self, ...): return True
+           def get(self, ...): return []
+           def health_check(self): return True
+           def get_stats(self): return IndexStats(...)
+           def search_by_metadata(self, ...): return []
+           async def search_by_text(self, ...): return []
        
        # In tests:
        store = MockVectorStore()
@@ -461,6 +465,33 @@ class BaseVectorStore(ABC):
         Raises:
             VectorStoreConnectionError: If connection to store fails.
             VectorStoreError: For other retrieval-related errors.
+        """
+        pass
+
+    @abstractmethod
+    async def search_by_text(
+        self,
+        query_text: str,
+        top_k: int = 2,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[SearchResult]:
+        """
+        Search for similar documents using a text query.
+
+        This is a convenience method that handles embedding the query text
+        before performing the vector search.
+
+        Args:
+            query_text: The text to embed and search for.
+            top_k: Number of results to return.
+            filters: Optional metadata filters.
+
+        Returns:
+            List of SearchResult objects sorted by similarity.
+
+        Raises:
+            VectorStoreConnectionError: If connection to store fails.
+            VectorStoreError: For other search-related errors.
         """
         pass
     

--- a/src/storage/pinecone.py
+++ b/src/storage/pinecone.py
@@ -79,11 +79,13 @@ class PineconeVectorStore(BaseVectorStore):
         ├── __init__()          # Constructor - sets up Pinecone connection
         │
         ├── CRUD Operations (from BaseVectorStore):
-        │   ├── add()           # Add vectors to the index
-        │   ├── search()        # Find similar vectors
-        │   ├── update()        # Update existing vector
-        │   ├── delete()        # Remove vectors
-        │   └── get()           # Retrieve vectors by ID
+        │   ├── add()                # Add vectors to the index
+        │   ├── search()             # Find similar vectors
+        │   ├── update()             # Update existing vector
+        │   ├── delete()             # Remove vectors
+        │   ├── get()                # Retrieve vectors by ID
+        │   ├── search_by_metadata() # Retrieve by metadata only
+        │   └── search_by_text()     # Embed text and search
         │
         ├── Management Operations (from BaseVectorStore):
         │   ├── health_check()  # Check connection status
@@ -859,7 +861,7 @@ class PineconeVectorStore(BaseVectorStore):
         )
     
     # ========================================================================
-    # PINECONE-SPECIFIC METHODS (not in BaseVectorStore)
+    # PINECONE-SPECIFIC METHODS (Internal helpers)
     # ========================================================================
     
     @with_retry(config=PINECONE_RETRY_CONFIG)
@@ -940,7 +942,7 @@ class PineconeVectorStore(BaseVectorStore):
         logger.info(f"Successfully deleted index: {self._index_name}")
     
     # ========================================================================
-    # METADATA-ONLY SEARCH (no embedding required)
+    # METADATA-ONLY SEARCH (BaseVectorStore interface)
     # ========================================================================
 
     @with_retry(config=PINECONE_RETRY_CONFIG)
@@ -951,6 +953,8 @@ class PineconeVectorStore(BaseVectorStore):
     ) -> List[SearchResult]:
         """
         Query Pinecone using only metadata filters.
+
+        This implements the abstract search_by_metadata() method from BaseVectorStore.
 
         Pinecone always requires a vector in the query call, so we supply a
         zero-vector and rely entirely on the metadata filter for selection.
@@ -1002,7 +1006,7 @@ class PineconeVectorStore(BaseVectorStore):
         return search_results
 
     # ========================================================================
-    # TEXT SEARCH (embeds the query, then searches by vector + filters)
+    # TEXT SEARCH (BaseVectorStore interface)
     # ========================================================================
 
     async def search_by_text(
@@ -1013,6 +1017,8 @@ class PineconeVectorStore(BaseVectorStore):
     ) -> List[SearchResult]:
         """
         Embed a query string and search for similar vectors.
+
+        This implements the abstract search_by_text() method from BaseVectorStore.
 
         This is a convenience wrapper that:
         1. Generates an embedding for `query_text` using SentenceTransformer.


### PR DESCRIPTION
This change improves the code health of the `JudgeAgent` by relying on the `BaseVectorStore` interface contract instead of using runtime `getattr` checks for abstract methods.

Key changes:
1.  **Interface Formalization**: Added `search_by_text` as an `@abstractmethod` in `BaseVectorStore`. This ensures all vector store implementations provide this convenience method, which is already used by the `JudgeAgent`.
2.  **Code Simplification**: Removed redundant `getattr` checks for `search_by_metadata` and `search_by_text` in `src/agents/judge.py`. This also allowed removing a fallback to semantic search that was previously used when `search_by_metadata` was missing, simplifying the logic.
3.  **Documentation Update**: Updated `PineconeVectorStore` docstrings and comments to reflect the updated interface contract.
4.  **Linting**: Fixed unused imports in `src/storage/base.py` identified by `ruff`.

These changes make the code more maintainable, readable, and type-safe by enforcing a consistent interface across the vector storage layer.

---
*PR created automatically by Jules for task [10208529608654575702](https://jules.google.com/task/10208529608654575702) started by @ishaanxgupta*