### PR TITLE
⚡ Bolt: Parallelize profile and temporal extraction calls

### DIFF
--- a/src/pipelines/ingest.py
+++ b/src/pipelines/ingest.py
@@ -365,8 +365,17 @@ class IngestPipeline:
         all_facts = []
         last_result = None
 
-        for query in queries:
-            result = await self.profiler.arun({"classifier_output": query})
+        # Parallelize profile extraction calls with concurrency limit
+        sem = asyncio.Semaphore(5)
+
+        async def _extract(q: str):
+            async with sem:
+                return await self.profiler.arun({"classifier_output": q})
+
+        tasks = [_extract(query) for query in queries]
+        results = await asyncio.gather(*tasks)
+
+        for result in results:
             if not result.is_empty:
                 all_facts.extend(result.facts)
                 last_result = result
@@ -403,11 +412,20 @@ class IngestPipeline:
         all_items: List[Dict[str, str]] = []
         last_result = None
 
-        for query in queries:
-            result = await self.temporal.arun({
-                "classifier_output": query,
-                "session_datetime": session_dt,
-            })
+        # Parallelize temporal event extraction calls with concurrency limit
+        sem = asyncio.Semaphore(5)
+
+        async def _extract(q: str):
+            async with sem:
+                return await self.temporal.arun({
+                    "classifier_output": q,
+                    "session_datetime": session_dt,
+                })
+
+        tasks = [_extract(query) for query in queries]
+        results = await asyncio.gather(*tasks)
+
+        for result in results:
             if not result.is_empty:
                 event = result.event
                 all_items.append({


### PR DESCRIPTION
⚡ Bolt: Parallelize profile and temporal extraction calls

💡 **What:** Refactored `src/pipelines/ingest.py` to execute batched profile and temporal extraction queries in parallel using `asyncio.gather`.
🎯 **Why:** Previously, these queries were executed sequentially in a loop. Since each query involves an I/O-bound LLM call, this created a bottleneck, increasing the total latency linearly with the number of sub-queries.
📊 **Impact:** Reduces the execution time for extraction steps from `O(N)` to `O(N/C)` (where C is concurrency limit, set to 5), effectively making it near-constant time for typical batches (1-5 queries).
🔬 **Measurement:** Verified with a unit test that mocks the agents and asserts that the `arun` methods are called the expected number of times. The parallel execution logic is standard `asyncio` pattern. Concurrency is limited to 5 to avoid rate limits.

---
*PR created automatically by Jules for task [17839362056145819528](https://jules.google.com/task/17839362056145819528) started by @ishaanxgupta*