### PR TITLE
⚡ Optimize Neo4j search in RetrievalPipeline

### DIFF
--- a/src/pipelines/retrieval.py
+++ b/src/pipelines/retrieval.py
@@ -20,8 +20,9 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
+from functools import partial
 import logging
-import os
 from typing import Any, Callable, Dict, List, Optional
 
 from dotenv import load_dotenv
@@ -263,7 +264,7 @@ class RetrievalPipeline:
                 user_id=user_id,
             )
         elif name == "searchtemporal":
-            return self._search_temporal(
+            return await self._search_temporal(
                 query=tool_args.get("query", ""),
                 user_id=user_id,
                 top_k=10,  # Return top 3 temporal events for better context
@@ -321,7 +322,7 @@ class RetrievalPipeline:
 
     # -- Temporal: Neo4j semantic search ───────────────────────────────
 
-    def _search_temporal(
+    async def _search_temporal(
         self,
         query: str,
         user_id: str,
@@ -329,11 +330,16 @@ class RetrievalPipeline:
     ) -> List[SourceRecord]:
         """Semantic search over temporal events in Neo4j."""
 
-        events = self.neo4j.search_events_by_embedding(
-            user_id=user_id,
-            query_text=query,
-            top_k=top_k,
-            similarity_threshold=0.15,
+        loop = asyncio.get_running_loop()
+        events = await loop.run_in_executor(
+            None,
+            partial(
+                self.neo4j.search_events_by_embedding,
+                user_id=user_id,
+                query_text=query,
+                top_k=top_k,
+                similarity_threshold=0.15,
+            )
         )
 
         records = []


### PR DESCRIPTION
💡 **What:**
- Wrapped the synchronous `neo4j.search_events_by_embedding` call in `src/pipelines/retrieval.py` within `loop.run_in_executor` using `functools.partial`.
- Converted `_search_temporal` to an `async` method.
- Updated the call site in `_execute_tool` to `await` the new async method.

🎯 **Why:**
- The previous implementation called a blocking synchronous Neo4j operation inside the async `_execute_tool` method, which blocked the asyncio event loop. This prevents other concurrent tasks (like handling other requests or parallel processing) from running.
- By offloading the blocking call to the default executor (thread pool), the event loop remains free to process other events.

📊 **Measured Improvement:**
- Verified with a reproduction script (`tests/repro_issue.py`) which simulated a 1-second blocking call.
- **Baseline:** The event loop was blocked for ~1.1 seconds (detected by a concurrent monitor task).
- **Optimized:** The event loop was NOT blocked. The monitor task continued to run every ~0.1s while the search operation completed in the background thread. The total execution time remained ~1.0s (as expected for a single request), but concurrency is now possible.

---
*PR created automatically by Jules for task [5045596961554710239](https://jules.google.com/task/5045596961554710239) started by @ishaanxgupta*