### PR TITLE
⚡ Bolt: add LRU cache to embed_text API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-01 - [Missing LRU Cache on Expensive External API Call]
+**Learning:** Found a critical performance bottleneck where `embed_text` in the ingestion pipeline (which makes network requests to Google GenAI for text embedding) lacked a caching mechanism. In this architecture, where operations are likely to encounter duplicate or common sentences during ingestion, failing to memoize expensive external API calls causes unnecessary latency, duplicate compute, and increases costs.
+**Action:** Always verify if deterministic external API calls (especially embedding generation or prompt retrieval) are using `functools.lru_cache` to ensure the application avoids repeated network requests and processes duplicates faster.

--- a/src/pipelines/ingest.py
+++ b/src/pipelines/ingest.py
@@ -50,6 +50,7 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -71,7 +72,7 @@ from src.pipelines.weaver import Weaver
 from src.schemas.classification import ClassificationResult
 from src.schemas.events import EventResult
 from src.schemas.image import ImageResult
-from src.schemas.judge import JudgeDomain, JudgeResult, OperationType
+from src.schemas.judge import JudgeDomain, JudgeResult
 from src.schemas.profile import ProfileResult
 from src.schemas.summary import SummaryResult
 from src.schemas.weaver import WeaverResult
@@ -85,8 +86,10 @@ logger = logging.getLogger("xmem.pipelines.ingest")
 # Embedding helper — wraps Google GenAI into a simple callable
 # ---------------------------------------------------------------------------
 
-from google import genai
-from google.genai import types
+# fmt: off
+from google import genai  # noqa: E402
+from google.genai import types  # noqa: E402
+# fmt: on
 
 _embedding_client: Optional[genai.Client] = None
 
@@ -100,8 +103,9 @@ def get_embedding_client() -> genai.Client:
     return _embedding_client
 
 
-def embed_text(text: str) -> List[float]:
-    """Embed a single text string → list of floats."""
+@functools.lru_cache(maxsize=1024)
+def embed_text(text: str) -> tuple[float, ...]:
+    """Embed a single text string → tuple of floats (cached)."""
     client = get_embedding_client()
     result = client.models.embed_content(
         model=settings.embedding_model,
@@ -109,7 +113,7 @@ def embed_text(text: str) -> List[float]:
         config=types.EmbedContentConfig(output_dimensionality=settings.pinecone_dimension)
     )
     [embedding_obj] = result.embeddings
-    return embedding_obj.values
+    return tuple(embedding_obj.values)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
💡 What: Added `@functools.lru_cache(maxsize=1024)` to `embed_text` in `src/pipelines/ingest.py`. Changed the return type from `List[float]` to `tuple[float, ...]` to ensure the cached value is immutable and prevents unintended cache mutation.
🎯 Why: The `embed_text` function was repeatedly making synchronous, expensive external network calls to Google GenAI for identical text during ingestion. Caching this function memoizes these requests.
📊 Impact: Reduces duplicate network latency significantly and lowers the cost of external embedding API calls for duplicate items.
🔬 Measurement: Can be verified by running the ingestion pipeline with duplicate text values; the Google GenAI embedding client will only receive network requests for the first call.
Also documented this learning in `.jules/bolt.md` to establish a new performance rule around caching deterministic API functions in the pipeline.

---
*PR created automatically by Jules for task [9365146226714906879](https://jules.google.com/task/9365146226714906879) started by @ishaanxgupta*