### PR TITLE
⚡ Bolt: Parallelize LLM extraction calls in IngestPipeline

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-02 - Parallelizing LLM extraction calls
+**Learning:** Ingest pipelines often loop sequentially over items (like batched queries) and `await` an LLM call per item. This causes severe bottlenecks due to blocking on network IO sequentially. Using `asyncio.gather` with an `asyncio.Semaphore` is a clean way to parallelize this and significantly improve throughput.
+**Action:** Always scan for `for` loops in `async` functions that `await` expensive external calls like model inference, and refactor them to run concurrently using bounded concurrency via semaphores.

--- a/src/pipelines/ingest.py
+++ b/src/pipelines/ingest.py
@@ -71,7 +71,7 @@ from src.pipelines.weaver import Weaver
 from src.schemas.classification import ClassificationResult
 from src.schemas.events import EventResult
 from src.schemas.image import ImageResult
-from src.schemas.judge import JudgeDomain, JudgeResult, OperationType
+from src.schemas.judge import JudgeDomain, JudgeResult
 from src.schemas.profile import ProfileResult
 from src.schemas.summary import SummaryResult
 from src.schemas.weaver import WeaverResult
@@ -365,11 +365,21 @@ class IngestPipeline:
         all_facts = []
         last_result = None
 
-        for query in queries:
-            result = await self.profiler.arun({"classifier_output": query})
-            if not result.is_empty:
-                all_facts.extend(result.facts)
-                last_result = result
+        if queries:
+            import asyncio
+            sem = asyncio.Semaphore(5)
+
+            async def _run_query(q: str):
+                async with sem:
+                    return await self.profiler.arun({"classifier_output": q})
+
+            # Run all queries in parallel, respecting the semaphore limit
+            results = await asyncio.gather(*[_run_query(q) for q in queries])
+
+            for result in results:
+                if not result.is_empty:
+                    all_facts.extend(result.facts)
+                    last_result = result
 
         if not all_facts:
             return {"status": "no_profile_facts"}
@@ -403,22 +413,32 @@ class IngestPipeline:
         all_items: List[Dict[str, str]] = []
         last_result = None
 
-        for query in queries:
-            result = await self.temporal.arun({
-                "classifier_output": query,
-                "session_datetime": session_dt,
-            })
-            if not result.is_empty:
-                event = result.event
-                all_items.append({
-                    "date": event.date,
-                    "event_name": event.event_name or "",
-                    "desc": event.desc or "",
-                    "year": event.year or "",
-                    "time": event.time or "",
-                    "date_expression": event.date_expression or "",
-                })
-                last_result = result
+        if queries:
+            import asyncio
+            sem = asyncio.Semaphore(5)
+
+            async def _run_query(q: str):
+                async with sem:
+                    return await self.temporal.arun({
+                        "classifier_output": q,
+                        "session_datetime": session_dt,
+                    })
+
+            # Run all queries in parallel, respecting the semaphore limit
+            results = await asyncio.gather(*[_run_query(q) for q in queries])
+
+            for result in results:
+                if not result.is_empty:
+                    event = result.event
+                    all_items.append({
+                        "date": event.date,
+                        "event_name": event.event_name or "",
+                        "desc": event.desc or "",
+                        "year": event.year or "",
+                        "time": event.time or "",
+                        "date_expression": event.date_expression or "",
+                    })
+                    last_result = result
 
         if not all_items:
             return {"status": "no_temporal_event"}


### PR DESCRIPTION
💡 What: Refactored `_node_extract_profile` and `_node_extract_temporal` in `src/pipelines/ingest.py` to use `asyncio.gather` with an `asyncio.Semaphore(5)` instead of sequentially `await`ing LLM calls in a `for` loop.
🎯 Why: Batched extractions were previously running sequentially, causing O(N) blocking network IO on LLM calls.
📊 Impact: Expected to significantly reduce total ingestion time (up to 5x faster for large batches) by concurrent processing of temporal and profile items.
🔬 Measurement: Run the ingestion pipeline with multiple batched inputs. The time difference between the original sequential code and this concurrent code will scale linearly with the number of batched queries. Also noted in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [8935839119909131526](https://jules.google.com/task/8935839119909131526) started by @ishaanxgupta*