### PR TITLE
add LRU cache to embed_text API calls

### DIFF
--- a/src/pipelines/ingest.py
+++ b/src/pipelines/ingest.py
@@ -49,6 +49,7 @@ Usage::
 
 from __future__ import annotations
 
+import functools
 import asyncio
 import logging
 from typing import Any, Callable, Dict, List, Optional
@@ -109,9 +110,9 @@ def get_embedding_client() -> genai.Client:
         logger.info("Loaded embedding client for model: %s", settings.embedding_model)
     return _embedding_client
 
-
-def embed_text(text: str) -> List[float]:
-    """Embed a single text string → list of floats."""
+@functools.lru_cache(max_size = 4096)
+def embed_text(text: str) -> tuple[float, ...]:
+    """Embed a single text string → tuple of floats."""
     client = get_embedding_client()
     result = client.models.embed_content(
         model=settings.embedding_model,
@@ -119,7 +120,7 @@ def embed_text(text: str) -> List[float]:
         config=types.EmbedContentConfig(output_dimensionality=settings.pinecone_dimension)
     )
     [embedding_obj] = result.embeddings
-    return embedding_obj.values
+    return tuple(embedding_obj.values)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Duplicate Facts: The Judge agent looks at incoming facts and decides if they should be ADDED or UPDATED. If a user repeats themselves ("My dog's name is Rex" today, and "My dog's name is Rex" tomorrow), the system embeds that string both times. Caching prevents the second API call entirely.
- Search Retries: When users ask similar questions, or when your pipeline triggers search_by_text for the same domain multiple times in a single session, it embeds the query. If the query is identical, it instantly returns the cached embedding.
- Code Scanning: I see in our grep results that embed_text is used by scanner/indexer.py and scanner/enricher.py. When scanning codebases, identical function signatures, docstrings, or small code chunks might appear multiple times across different branches or files.