### PR TITLE
⚡ Bolt: [performance improvement] Prevent LLM API rate limits during parallel extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+
+2026-03-08:
+⚡ Bolt: Add concurrency control using `asyncio.Semaphore` to parallel ingest queries.
+- **What**: Capped the concurrent sub-queries executed via `asyncio.gather` with a semaphore in extraction nodes.
+- **Why**: When a large number of profile/temporal/code queries are generated, unbounded parallel execution via `asyncio.gather` causes LLM API rate limits. Bounding them ensures throughput while keeping the workflow reliable.
+- **Impact**: Stabilizes ingest pipeline during heavy loads with many sub-queries.
+- **Measurement**: Benchmarks demonstrated capping parallel execution bounds the rate of API calls without sacrificing baseline latency per query batch.

--- a/src/pipelines/ingest.py
+++ b/src/pipelines/ingest.py
@@ -81,7 +81,7 @@ from src.schemas.code import (
 )
 from src.schemas.events import EventResult
 from src.schemas.image import ImageResult
-from src.schemas.judge import JudgeDomain, JudgeResult, OperationType
+from src.schemas.judge import JudgeDomain, JudgeResult
 from src.schemas.profile import ProfileResult
 from src.schemas.summary import SummaryResult
 from src.schemas.weaver import WeaverResult
@@ -95,8 +95,8 @@ logger = logging.getLogger("xmem.pipelines.ingest")
 # Embedding helper — wraps Google GenAI into a simple callable
 # ---------------------------------------------------------------------------
 
-from google import genai
-from google.genai import types
+from google import genai  # noqa: E402
+from google.genai import types  # noqa: E402
 
 _embedding_client: Optional[genai.Client] = None
 
@@ -488,9 +488,12 @@ class IngestPipeline:
         all_facts = []
         last_result = None
 
-        results = await asyncio.gather(
-            *(self.profiler.arun({"classifier_output": q}) for q in queries)
-        )
+        # Prevent LLM API rate limiting by capping concurrent sub-queries
+        sem = asyncio.Semaphore(5)
+        async def _bounded_extract(q):
+            async with sem:
+                return await self.profiler.arun({"classifier_output": q})
+        results = await asyncio.gather(*(_bounded_extract(q) for q in queries))
         for result in results:
             if not result.is_empty:
                 all_facts.extend(result.facts)
@@ -528,12 +531,15 @@ class IngestPipeline:
         all_items: List[Dict[str, str]] = []
         last_result = None
 
-        results = await asyncio.gather(
-            *(self.temporal.arun({
+        # Prevent LLM API rate limiting by capping concurrent sub-queries
+        sem = asyncio.Semaphore(5)
+        async def _bounded_extract(q):
+            async with sem:
+                return await self.temporal.arun({
                 "classifier_output": q,
                 "session_datetime": session_dt,
-            }) for q in queries)
-        )
+            })
+        results = await asyncio.gather(*(_bounded_extract(q) for q in queries))
         for result in results:
             if not result.is_empty:
                 for event in result.events:
@@ -617,9 +623,12 @@ class IngestPipeline:
         all_items: List[str] = []
         last_result = None
 
-        results = await asyncio.gather(
-            *(self.code_agent.arun({"classifier_output": q}) for q in queries)
-        )
+        # Prevent LLM API rate limiting by capping concurrent sub-queries
+        sem = asyncio.Semaphore(5)
+        async def _bounded_extract(q):
+            async with sem:
+                return await self.code_agent.arun({"classifier_output": q})
+        results = await asyncio.gather(*(_bounded_extract(q) for q in queries))
         for result in results:
             if not result.is_empty:
                 for ann in result.annotations:
@@ -662,9 +671,12 @@ class IngestPipeline:
         all_items: List[str] = []
         last_result = None
 
-        results = await asyncio.gather(
-            *(self.snippet_agent.arun({"classifier_output": q}) for q in queries)
-        )
+        # Prevent LLM API rate limiting by capping concurrent sub-queries
+        sem = asyncio.Semaphore(5)
+        async def _bounded_extract(q):
+            async with sem:
+                return await self.snippet_agent.arun({"classifier_output": q})
+        results = await asyncio.gather(*(_bounded_extract(q) for q in queries))
         for result in results:
             if not result.is_empty:
                 for snip in result.snippets:


### PR DESCRIPTION
💡 **What:** Added concurrency control using \`asyncio.Semaphore(5)\` to bound the number of concurrent LLM calls during batched extractions in \`_node_extract_profile\`, \`_node_extract_temporal\`, \`_node_extract_code\`, and \`_node_extract_snippet\`.
🎯 **Why:** While \`asyncio.gather\` was used to parallelize sub-queries across the LLM, doing so unbounded could cause API rate limiting errors when a user query generates a large number of profile/temporal/code/snippet sub-queries. Bounding concurrency balances throughput and stability.
📊 **Measured Improvement:** The underlying performance logic (using \`asyncio.gather\`) is preserved and effectively optimized by preventing failures under heavy load. A benchmark simulating network API latency showed no degradation for small sets of queries, while effectively capping concurrency at 5 requests at a time to keep it robust against rate limit crashes.

---
*PR created automatically by Jules for task [8918555165628498996](https://jules.google.com/task/8918555165628498996) started by @ishaanxgupta*