### PR TITLE
🧪 [Testing] Add edge case test for short text parts in parse_raw_response_to_classifications

### DIFF
--- a/tests/unit/utils/test_text.py
+++ b/tests/unit/utils/test_text.py
@@ -56,3 +56,25 @@ class TestParseClassifications:
         assert parse_raw_response_to_classifications("") == []
         assert parse_raw_response_to_classifications("(empty)") == []
 
+
+    def test_short_parts_edge_case(self):
+        """
+        Tests the edge case where parts < 2.
+        This branch is normally unreachable with standard strings because we previously
+        ensure that LLM_TAB_SEPARATOR is in the line.
+        We test it using a mock object that overrides __contains__ and split.
+        """
+        class MockStr(str):
+            def __contains__(self, item):
+                return True
+            def split(self, *args, **kwargs):
+                return ["single_part"]
+
+        class MockContent:
+            def strip(self):
+                return self
+            def splitlines(self):
+                return [MockStr("dummy")]
+
+        result = parse_raw_response_to_classifications(MockContent())
+        assert result == []


### PR DESCRIPTION
🎯 **What:** I added an edge-case test for the condition `if len(parts) < 2:` inside the `parse_raw_response_to_classifications` method in `src/utils/text.py`. Since a previous check `if LLM_TAB_SEPARATOR not in line:` inherently guarantees standard string operations will yield `len(parts) >= 2`, I simulated the impossible scenario using a `MockStr` mock object.

📊 **Coverage:** The test explicitly triggers the branch that ignores lines if splitting by the separator somehow results in less than 2 parts, providing code coverage and protecting against regressions.

✨ **Result:** A new unit test was added, increasing test coverage for the fallback/defensive logic inside the text extraction utilities.

---
*PR created automatically by Jules for task [4330361933607348673](https://jules.google.com/task/4330361933607348673) started by @ishaanxgupta*