### PR TITLE
⚡ Bolt: [performance improvement] Concurrent tool execution in Retrieval Pipelines

### DIFF
--- a/src/pipelines/code_retrieval.py
+++ b/src/pipelines/code_retrieval.py
@@ -25,6 +25,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -375,11 +376,9 @@ class CodeRetrievalPipeline:
             turn_records: List[SourceRecord] = []
             only_read_tools = True
 
-            for tc in ai_response.tool_calls:
+            async def _process_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 t1 = _time.perf_counter()
                 records = await self._execute_tool(
                     tool_name, tool_args, repo=repo, top_k=top_k,
@@ -387,6 +386,14 @@ class CodeRetrievalPipeline:
                 )
                 tool_ms = (_time.perf_counter() - t1) * 1000
                 logger.info("  Tool: %s(%s) → %d results (%.0fms)", tool_name, tool_args, len(records), tool_ms)
+                return tc, records
+
+            results = await asyncio.gather(*(_process_tool_call(tc) for tc in ai_response.tool_calls))
+
+            for tc, records in results:
+                tool_name = tc["name"]
+                tool_id = tc["id"]
+
                 turn_records.extend(records)
                 sources.extend(records)
 
@@ -589,14 +596,19 @@ class CodeRetrievalPipeline:
     ) -> List[SourceRecord]:
         if not repo:
             logger.warning("search_symbols called without repo — searching all repos")
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            all_results = await asyncio.gather(*(
+                self._search_namespace(
                     namespace=symbols_namespace(self.org_id, r),
                     query=query,
                     domain="symbol",
                     top_k=top_k,
-                ))
+                )
+                for r in self.repos
+            ))
+
+            results = []
+            for res in all_results:
+                results.extend(res)
             return results[:top_k]
 
         return await self._search_namespace(
@@ -612,14 +624,19 @@ class CodeRetrievalPipeline:
         self, query: str, repo: str, top_k: int = 10,
     ) -> List[SourceRecord]:
         if not repo:
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            all_results = await asyncio.gather(*(
+                self._search_namespace(
                     namespace=files_namespace(self.org_id, r),
                     query=query,
                     domain="file",
                     top_k=top_k,
-                ))
+                )
+                for r in self.repos
+            ))
+
+            results = []
+            for res in all_results:
+                results.extend(res)
             return results[:top_k]
 
         return await self._search_namespace(

--- a/src/pipelines/retrieval.py
+++ b/src/pipelines/retrieval.py
@@ -20,6 +20,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from typing import Any, Callable, Dict, List, Optional
@@ -177,16 +178,21 @@ class RetrievalPipeline:
 
         if ai_response.tool_calls:
             called_tools = set()
-            for tc in ai_response.tool_calls:
+
+            async def _process_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 logger.info("  Tool call: %s(%s)", tool_name, tool_args)
-
                 records = await self._execute_tool(
                     tool_name, tool_args, user_id, top_k,
                 )
+                return tc, records
+
+            results = await asyncio.gather(*(_process_tool_call(tc) for tc in ai_response.tool_calls))
+
+            for tc, records in results:
+                tool_name = tc["name"]
+                tool_id = tc["id"]
                 sources.extend(records)
 
                 # Build ToolMessage for the LLM


### PR DESCRIPTION
💡 **What**: The optimization refactors sequential `for` loops into concurrent execution using `asyncio.gather` for LLM tool executions (`_execute_tool`) in both `RetrievalPipeline` and `CodeRetrievalPipeline`. It also refactors `_search_symbols` and `_search_files` to search multiple repositories in parallel.

🎯 **Why**: When an LLM decides to use multiple tools (e.g., searching for semantic vectors, asking a graph database, looking up profiles), these calls are independent. Sequentially executing them in a `for` loop unnecessarily throttles the process and compounds external latency. Fetching them concurrently hides the latency behind the slowest request.

📊 **Impact**: Reduces total tool execution time significantly. If the LLM makes 3 tool calls taking 200ms, 300ms, and 400ms respectively, the wait time drops from ~900ms to ~400ms. Similarly, querying 5 repositories will now be as fast as the single slowest repository query.

🔬 **Measurement**: Use telemetry logs; trace the elapsed time `tool_ms` for tool execution blocks and note the overall turn execution time dropping linearly with the number of parallel tools called.

---
*PR created automatically by Jules for task [3952276918833983431](https://jules.google.com/task/3952276918833983431) started by @ishaanxgupta*