### PR TITLE
⚡ Bolt: [performance improvement] Bulk process symbol upserts in Indexer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-27 - Batch processing for Code Symbol Indexing
+**Learning:** Indexing large codebases with individual database and vector store writes results in severe N+1 query overhead, particularly due to the latency of multiple API calls per symbol to Pinecone, MongoDB, and Neo4j. Even minor code changes can trigger hundreds of individual sequential updates.
+**Action:** Use batch processing for symbol updates. Collect all changed symbols within `Indexer._process_file` and perform bulk upserts using `CodeStore.upsert_symbols_bulk`, `PineconeVectorStore.add`, and a newly added `CodeGraphClient.upsert_symbols_bulk`. Also ensure embeddings are generated in batches using `embed_texts`.


### PR DESCRIPTION
💡 What: Replaced individual symbol upserts with bulk processing in `Indexer._process_file`.
🎯 Why: Indexing large files with many symbols caused severe N+1 query overhead, as each symbol change resulted in sequential write requests to MongoDB, Pinecone, and Neo4j, as well as sequential embedding generations.
📊 Impact: Significantly reduces indexing latency by batching database writes and embeddings. A file with 100 symbols will now trigger ~3 bulk API calls instead of 300 individual calls.
🔬 Measurement: Run a scan against a repository (`scan_repo`). Observe the overall scan duration logged in `duration_seconds` to verify improved performance.

---
*PR created automatically by Jules for task [17930675043780213757](https://jules.google.com/task/17930675043780213757) started by @ishaanxgupta*