### PR TITLE
⚡ Bolt: execute LLM retrieval tools concurrently

### DIFF
--- a/src/pipelines/code_retrieval.py
+++ b/src/pipelines/code_retrieval.py
@@ -25,6 +25,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -37,7 +38,6 @@ from src.graph.code_graph_client import CodeGraphClient
 from src.scanner.code_store import CodeStore
 from src.schemas.code import (
     annotations_namespace,
-    directories_namespace,
     files_namespace,
     snippets_namespace,
     symbols_namespace,
@@ -375,11 +375,9 @@ class CodeRetrievalPipeline:
             turn_records: List[SourceRecord] = []
             only_read_tools = True
 
-            for tc in ai_response.tool_calls:
+            async def _process_tool_call(tc: Dict[str, Any]) -> tuple[List[SourceRecord], Dict[str, Any], bool]:
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 t1 = _time.perf_counter()
                 records = await self._execute_tool(
                     tool_name, tool_args, repo=repo, top_k=top_k,
@@ -387,17 +385,23 @@ class CodeRetrievalPipeline:
                 )
                 tool_ms = (_time.perf_counter() - t1) * 1000
                 logger.info("  Tool: %s(%s) → %d results (%.0fms)", tool_name, tool_args, len(records), tool_ms)
+
+                normalized = tool_name.lower().replace("_", "")
+                is_read_only = normalized in ("readfilecode", "readsymbolcode", "getfilecontext")
+                return records, tc, is_read_only
+
+            results = await asyncio.gather(*[_process_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for records, tc, is_read_only in results:
+                if not is_read_only:
+                    only_read_tools = False
+
                 turn_records.extend(records)
                 sources.extend(records)
 
-                # Track if this turn ONLY used read tools (no search)
-                normalized = tool_name.lower().replace("_", "")
-                if normalized not in ("readfilecode", "readsymbolcode", "getfilecontext"):
-                    only_read_tools = False
-
                 tool_result_text = self._format_tool_results(records)
                 messages.append(
-                    ToolMessage(content=tool_result_text, tool_call_id=tool_id)
+                    ToolMessage(content=tool_result_text, tool_call_id=tc["id"])
                 )
 
             # ⚡ SHORT-CIRCUIT: if the LLM only called read tools,
@@ -471,22 +475,23 @@ class CodeRetrievalPipeline:
         if ai_response.tool_calls:
             yield json.dumps({"type": "status", "content": f"Running {len(ai_response.tool_calls)} search tool(s)..."}) + "\n"
             
-            for tc in ai_response.tool_calls:
+            async def _process_stream_tool_call(tc: Dict[str, Any]) -> tuple[List[SourceRecord], Dict[str, Any]]:
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 logger.info("  Tool: %s(%s)", tool_name, tool_args)
-
                 records = await self._execute_tool(
                     tool_name, tool_args, repo=repo, top_k=top_k,
                     user_id=user_id,
                 )
-                sources.extend(records)
+                return records, tc
 
+            results = await asyncio.gather(*[_process_stream_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for records, tc in results:
+                sources.extend(records)
                 tool_result_text = self._format_tool_results(records)
                 tool_messages.append(
-                    ToolMessage(content=tool_result_text, tool_call_id=tool_id)
+                    ToolMessage(content=tool_result_text, tool_call_id=tc["id"])
                 )
 
             # Send sources early

--- a/src/pipelines/retrieval.py
+++ b/src/pipelines/retrieval.py
@@ -20,8 +20,8 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import logging
-import os
 from typing import Any, Callable, Dict, List, Optional
 
 from dotenv import load_dotenv
@@ -177,22 +177,26 @@ class RetrievalPipeline:
 
         if ai_response.tool_calls:
             called_tools = set()
-            for tc in ai_response.tool_calls:
+
+            async def _process_tool_call(tc: Dict[str, Any]) -> tuple[List[SourceRecord], Dict[str, Any]]:
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 logger.info("  Tool call: %s(%s)", tool_name, tool_args)
-
                 records = await self._execute_tool(
                     tool_name, tool_args, user_id, top_k,
                 )
+                return records, tc
+
+            results = await asyncio.gather(*[_process_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for records, tc in results:
+                tool_name = tc["name"]
                 sources.extend(records)
 
                 # Build ToolMessage for the LLM
                 tool_result_text = self._format_tool_results(records)
                 tool_messages.append(
-                    ToolMessage(content=tool_result_text, tool_call_id=tool_id)
+                    ToolMessage(content=tool_result_text, tool_call_id=tc["id"])
                 )
 
                 called_tools.add(tool_name.lower().replace("_", ""))


### PR DESCRIPTION
💡 **What**: Refactored the tool execution loops in `CodeRetrievalPipeline.run`, `CodeRetrievalPipeline.run_stream`, and `RetrievalPipeline.run` to execute LLM-suggested tool calls concurrently using `asyncio.gather`. 

🎯 **Why**: When the LLM decides to use multiple tools (e.g., calling `search_symbols` and `search_files` together), executing them sequentially is highly inefficient since these operations are I/O bound (querying Pinecone, Neo4j, MongoDB, etc.). `asyncio.gather` enables true parallel execution of these network requests without changing the API's behavior. The results are assembled sequentially after the parallel wait to guarantee that tool messages are strictly ordered as requested.

📊 **Impact**: Expected to reduce the total latency of the tool-execution phase significantly. For example, if a multi-tool query takes $T_1 + T_2 + ... + T_n$ to resolve sequentially, it will now take approximately $max(T_1, T_2, ..., T_n)$. Total pipeline latency in multi-tool scenarios should see a marked improvement.

🔬 **Measurement**: Verify by sending a query that requires the LLM to search multiple namespaces (e.g., "Find the payment processor logic and its impact"). Observe the tool execution log timestamps; the total duration will be bound by the slowest single query rather than the sum of all queries.

---
*PR created automatically by Jules for task [4260095040476073666](https://jules.google.com/task/4260095040476073666) started by @ishaanxgupta*