### PR TITLE
⚡ Bolt: [Optimize multi-repo search latency]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Optimizing code retrieval search pipelines]
+**Learning:** Sequential namespace lookups for cross-repository search (e.g., in `_search_symbols`, `_search_files`) create N+1 query overhead in Pinecone/Neo4j searches, blocking I/O bound loops.
+**Action:** Always prefer `asyncio.gather` for independent `_search_namespace` calls when iterating across multiple repositories to bound latency to the slowest search rather than the sum of all searches.

--- a/src/pipelines/code_retrieval.py
+++ b/src/pipelines/code_retrieval.py
@@ -25,6 +25,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -37,7 +38,6 @@ from src.graph.code_graph_client import CodeGraphClient
 from src.scanner.code_store import CodeStore
 from src.schemas.code import (
     annotations_namespace,
-    directories_namespace,
     files_namespace,
     snippets_namespace,
     symbols_namespace,
@@ -589,14 +589,17 @@ class CodeRetrievalPipeline:
     ) -> List[SourceRecord]:
         if not repo:
             logger.warning("search_symbols called without repo — searching all repos")
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            tasks = [
+                self._search_namespace(
                     namespace=symbols_namespace(self.org_id, r),
                     query=query,
                     domain="symbol",
                     top_k=top_k,
-                ))
+                )
+                for r in self.repos
+            ]
+            repo_results = await asyncio.gather(*tasks)
+            results = [record for sublist in repo_results for record in sublist]
             return results[:top_k]
 
         return await self._search_namespace(
@@ -612,14 +615,17 @@ class CodeRetrievalPipeline:
         self, query: str, repo: str, top_k: int = 10,
     ) -> List[SourceRecord]:
         if not repo:
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            tasks = [
+                self._search_namespace(
                     namespace=files_namespace(self.org_id, r),
                     query=query,
                     domain="file",
                     top_k=top_k,
-                ))
+                )
+                for r in self.repos
+            ]
+            repo_results = await asyncio.gather(*tasks)
+            results = [record for sublist in repo_results for record in sublist]
             return results[:top_k]
 
         return await self._search_namespace(


### PR DESCRIPTION
💡 **What:** 
Replaced sequential `for` loops in the `_search_symbols` and `_search_files` methods of `CodeRetrievalPipeline` with `asyncio.gather` for concurrent searches across namespaces, flattening the resulting matrix of records into a single list.

🎯 **Why:** 
Previously, when querying without a specific repository, the application performed sequential Pinecone semantic searches for each repository. This introduced an N+1 query latency bottleneck for I/O operations, meaning multi-repo searches took `O(R)` time where `R` is the number of repositories.

📊 **Impact:** 
Bounds the multi-repository search latency to roughly `max(latency(repo_i))` instead of `sum(latency(repo_i))`, drastically improving response times for broader searches across the organization. Expected speedup corresponds to the number of configured repositories.

🔬 **Measurement:**
Execution time of `search_symbols(query, repo=None)` and `search_files(query, repo=None)` will be significantly shorter. Verification was done via static analysis, code linting, and checking syntax since integration tests for vector stores are mocked/environment-dependent.

---
*PR created automatically by Jules for task [16987167789368732917](https://jules.google.com/task/16987167789368732917) started by @ishaanxgupta*