### PR TITLE
🔒 [security fix] Fix Git Command Injection via GitHub URL validation

### DIFF
--- a/src/api/routes/scanner.py
+++ b/src/api/routes/scanner.py
@@ -66,11 +66,12 @@ class ChatRequest(BaseModel):
 def _parse_github_url(url: str) -> tuple:
     """Extract (org, repo) from a GitHub URL."""
     url = url.strip().rstrip("/")
-    m = re.search(r"github\.com[/:]([^/]+)/([^/.]+?)(?:\.git)?$", url)
+    # Anchor to https://github.com/ and use re.match to prevent injection
+    m = re.match(r"^https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$", url)
     if m:
         return m.group(1), m.group(2)
     raise ValueError(
-        f"Invalid GitHub URL. Expected format: https://github.com/org/repo"
+        "Invalid GitHub URL. Expected format: https://github.com/org/repo"
     )
 
 


### PR DESCRIPTION
🎯 **What:** The `_parse_github_url` function was vulnerable to Git command injection because it used a permissive `re.search` on GitHub URLs without protocol enforcement.

⚠️ **Risk:** An attacker could provide a malicious URL like `-oProxyCommand=... github.com/org/repo` which, when passed to `git clone`, could lead to Remote Code Execution (RCE).

🛡️ **Solution:** The fix enforces a strict `https://github.com/` prefix using `re.match` and proper regex anchoring. This prevents transport protocol injection and ensures only valid GitHub HTTPS URLs are processed. Repo name matching was also improved to support dots (e.g., `project.js`).

---
*PR created automatically by Jules for task [16532801000163708157](https://jules.google.com/task/16532801000163708157) started by @ishaanxgupta*