### PR TITLE
⚡ Bolt: [performance improvement] Optimize retrieval pipelines with concurrent tool execution and multi-repo search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-01 - [Optimization: Concurrent Execution in Retrieval Pipelines]
+**Learning:** Sequential await execution for LLM tool calls and multi-repository searches introduces unnecessary latency bottlenecks. Offloading these independent sub-queries concurrently via `asyncio.gather` significantly reduces wait time and allows for parallel IO operations to scale, though we need to correctly unpack results sequentially back into standard Python lists to preserve state safety.
+**Action:** Always prefer `asyncio.gather` over sequential `for loop` and `await` operations when retrieving results across namespaces, repositories, or multiple LLM tool executions. Wrap the loop bodies in asynchronous internal functions or generator expressions to process tasks safely.

--- a/src/pipelines/code_retrieval.py
+++ b/src/pipelines/code_retrieval.py
@@ -37,7 +37,6 @@ from src.graph.code_graph_client import CodeGraphClient
 from src.scanner.code_store import CodeStore
 from src.schemas.code import (
     annotations_namespace,
-    directories_namespace,
     files_namespace,
     snippets_namespace,
     symbols_namespace,
@@ -375,11 +374,10 @@ class CodeRetrievalPipeline:
             turn_records: List[SourceRecord] = []
             only_read_tools = True
 
-            for tc in ai_response.tool_calls:
+            import asyncio
+            async def _process_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 t1 = _time.perf_counter()
                 records = await self._execute_tool(
                     tool_name, tool_args, repo=repo, top_k=top_k,
@@ -387,6 +385,13 @@ class CodeRetrievalPipeline:
                 )
                 tool_ms = (_time.perf_counter() - t1) * 1000
                 logger.info("  Tool: %s(%s) → %d results (%.0fms)", tool_name, tool_args, len(records), tool_ms)
+                return tc, records
+
+            tool_results = await asyncio.gather(*[_process_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for tc, records in tool_results:
+                tool_name = tc["name"]
+                tool_id = tc["id"]
                 turn_records.extend(records)
                 sources.extend(records)
 
@@ -471,19 +476,22 @@ class CodeRetrievalPipeline:
         if ai_response.tool_calls:
             yield json.dumps({"type": "status", "content": f"Running {len(ai_response.tool_calls)} search tool(s)..."}) + "\n"
             
-            for tc in ai_response.tool_calls:
+            import asyncio
+            async def _process_stream_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 logger.info("  Tool: %s(%s)", tool_name, tool_args)
-
                 records = await self._execute_tool(
                     tool_name, tool_args, repo=repo, top_k=top_k,
                     user_id=user_id,
                 )
-                sources.extend(records)
+                return tc, records
 
+            stream_tool_results = await asyncio.gather(*[_process_stream_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for tc, records in stream_tool_results:
+                tool_id = tc["id"]
+                sources.extend(records)
                 tool_result_text = self._format_tool_results(records)
                 tool_messages.append(
                     ToolMessage(content=tool_result_text, tool_call_id=tool_id)
@@ -589,14 +597,16 @@ class CodeRetrievalPipeline:
     ) -> List[SourceRecord]:
         if not repo:
             logger.warning("search_symbols called without repo — searching all repos")
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            import asyncio
+            results_nested = await asyncio.gather(*(
+                self._search_namespace(
                     namespace=symbols_namespace(self.org_id, r),
                     query=query,
                     domain="symbol",
                     top_k=top_k,
-                ))
+                ) for r in self.repos
+            ))
+            results = [record for sublist in results_nested for record in sublist]
             return results[:top_k]
 
         return await self._search_namespace(
@@ -612,14 +622,16 @@ class CodeRetrievalPipeline:
         self, query: str, repo: str, top_k: int = 10,
     ) -> List[SourceRecord]:
         if not repo:
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            import asyncio
+            results_nested = await asyncio.gather(*(
+                self._search_namespace(
                     namespace=files_namespace(self.org_id, r),
                     query=query,
                     domain="file",
                     top_k=top_k,
-                ))
+                ) for r in self.repos
+            ))
+            results = [record for sublist in results_nested for record in sublist]
             return results[:top_k]
 
         return await self._search_namespace(

--- a/src/pipelines/ingest.py
+++ b/src/pipelines/ingest.py
@@ -82,7 +82,7 @@ from src.schemas.code import (
 )
 from src.schemas.events import EventResult
 from src.schemas.image import ImageResult
-from src.schemas.judge import JudgeDomain, JudgeResult, OperationType
+from src.schemas.judge import JudgeDomain, JudgeResult
 from src.schemas.profile import ProfileResult
 from src.schemas.summary import SummaryResult
 from src.schemas.weaver import WeaverResult
@@ -97,10 +97,10 @@ logger = logging.getLogger("xmem.pipelines.ingest")
 # Embedding helper — supports Google GenAI and Amazon Bedrock (Nova)
 # ---------------------------------------------------------------------------
 
-import json as _json
+import json as _json  # noqa: E402
 
-from google import genai
-from google.genai import types
+from google import genai  # noqa: E402
+from google.genai import types  # noqa: E402
 
 _embedding_client: Optional[genai.Client] = None
 _bedrock_embedding_client = None

--- a/src/pipelines/retrieval.py
+++ b/src/pipelines/retrieval.py
@@ -21,7 +21,6 @@ Usage:
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Callable, Dict, List, Optional
 
 from dotenv import load_dotenv
@@ -177,16 +176,21 @@ class RetrievalPipeline:
 
         if ai_response.tool_calls:
             called_tools = set()
-            for tc in ai_response.tool_calls:
+            import asyncio
+            async def _process_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 logger.info("  Tool call: %s(%s)", tool_name, tool_args)
-
                 records = await self._execute_tool(
                     tool_name, tool_args, user_id, top_k,
                 )
+                return tc, records
+
+            tool_results = await asyncio.gather(*[_process_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for tc, records in tool_results:
+                tool_name = tc["name"]
+                tool_id = tc["id"]
                 sources.extend(records)
 
                 # Build ToolMessage for the LLM


### PR DESCRIPTION
💡 What: 
Refactored the main execution flows in `CodeRetrievalPipeline` and `RetrievalPipeline` to execute multiple LLM tool calls concurrently using `asyncio.gather()`. In `CodeRetrievalPipeline`, also modified `_search_symbols` and `_search_files` to search across multiple repositories in parallel.

🎯 Why: 
Previously, if the LLM generated multiple tool calls (e.g., retrieving details across multiple files or namespaces), the pipeline processed them sequentially via a standard `for` loop with `await`. Similarly, searching across multiple repositories was processed one repo at a time. This introduced unnecessary sequential IO bottlenecks, increasing the total time taken before the pipeline could return an answer. 

📊 Impact: 
Reduces the overall retrieval latency linearly relative to the number of tool calls / repositories being searched. A multi-repo query hitting 5 repos or generating 4 tool calls will now take roughly the time of a single slowest operation, drastically reducing the LLM's perceived response time.

🔬 Measurement: 
This improvement can be verified by observing the `(%.0fms)` debug logs produced by `logger.info("  Tool: ...")` in the console during a query requiring multiple tool searches. The overall turnaround time reported at the end of the pipeline run will be significantly shorter.

---
*PR created automatically by Jules for task [9184105272501670982](https://jules.google.com/task/9184105272501670982) started by @ishaanxgupta*