### PR TITLE
⚡ Bolt: [performance] Concurrent tool execution and multi-repo search in retrieval pipelines

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-25 - Concurrent tool call execution in Retrieval Pipelines
+**Learning:** Sequential execution of multiple tool calls in LangChain AIMessage (e.g. querying Pinecone and Neo4j simultaneously) creates a significant latency bottleneck in `RetrievalPipeline` and `CodeRetrievalPipeline`. A similar sequential bottleneck exists when searching across multiple repositories.
+**Action:** Use `asyncio.gather` to execute independent tool calls and multi-namespace searches concurrently, then process results sequentially to safely update shared state.

--- a/src/pipelines/code_retrieval.py
+++ b/src/pipelines/code_retrieval.py
@@ -375,17 +375,23 @@ class CodeRetrievalPipeline:
             turn_records: List[SourceRecord] = []
             only_read_tools = True
 
-            for tc in ai_response.tool_calls:
-                tool_name = tc["name"]
-                tool_args = tc["args"]
-                tool_id = tc["id"]
-
+            async def _process_tool_call(tc: Dict[str, Any]) -> tuple[str, str, str, List[SourceRecord], float]:
+                t_name = tc["name"]
+                t_args = tc["args"]
+                t_id = tc["id"]
                 t1 = _time.perf_counter()
-                records = await self._execute_tool(
-                    tool_name, tool_args, repo=repo, top_k=top_k,
-                    user_id=user_id,
+                recs = await self._execute_tool(
+                    t_name, t_args, repo=repo, top_k=top_k, user_id=user_id,
                 )
-                tool_ms = (_time.perf_counter() - t1) * 1000
+                t_ms = (_time.perf_counter() - t1) * 1000
+                return t_name, t_args, t_id, recs, t_ms
+
+            import asyncio
+            results = await asyncio.gather(*(
+                _process_tool_call(tc) for tc in ai_response.tool_calls
+            ))
+
+            for tool_name, tool_args, tool_id, records, tool_ms in results:
                 logger.info("  Tool: %s(%s) → %d results (%.0fms)", tool_name, tool_args, len(records), tool_ms)
                 turn_records.extend(records)
                 sources.extend(records)
@@ -471,17 +477,22 @@ class CodeRetrievalPipeline:
         if ai_response.tool_calls:
             yield json.dumps({"type": "status", "content": f"Running {len(ai_response.tool_calls)} search tool(s)..."}) + "\n"
             
-            for tc in ai_response.tool_calls:
-                tool_name = tc["name"]
-                tool_args = tc["args"]
-                tool_id = tc["id"]
-
-                logger.info("  Tool: %s(%s)", tool_name, tool_args)
-
-                records = await self._execute_tool(
-                    tool_name, tool_args, repo=repo, top_k=top_k,
-                    user_id=user_id,
+            async def _process_stream_tool_call(tc: Dict[str, Any]) -> tuple[str, str, str, List[SourceRecord]]:
+                t_name = tc["name"]
+                t_args = tc["args"]
+                t_id = tc["id"]
+                logger.info("  Tool: %s(%s)", t_name, t_args)
+                recs = await self._execute_tool(
+                    t_name, t_args, repo=repo, top_k=top_k, user_id=user_id,
                 )
+                return t_name, t_args, t_id, recs
+
+            import asyncio
+            results = await asyncio.gather(*(
+                _process_stream_tool_call(tc) for tc in ai_response.tool_calls
+            ))
+
+            for tool_name, tool_args, tool_id, records in results:
                 sources.extend(records)
 
                 tool_result_text = self._format_tool_results(records)
@@ -589,14 +600,16 @@ class CodeRetrievalPipeline:
     ) -> List[SourceRecord]:
         if not repo:
             logger.warning("search_symbols called without repo — searching all repos")
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            import asyncio
+            repo_results = await asyncio.gather(*(
+                self._search_namespace(
                     namespace=symbols_namespace(self.org_id, r),
                     query=query,
                     domain="symbol",
                     top_k=top_k,
-                ))
+                ) for r in self.repos
+            ))
+            results = [item for sublist in repo_results for item in sublist]
             return results[:top_k]
 
         return await self._search_namespace(
@@ -612,14 +625,16 @@ class CodeRetrievalPipeline:
         self, query: str, repo: str, top_k: int = 10,
     ) -> List[SourceRecord]:
         if not repo:
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            import asyncio
+            repo_results = await asyncio.gather(*(
+                self._search_namespace(
                     namespace=files_namespace(self.org_id, r),
                     query=query,
                     domain="file",
                     top_k=top_k,
-                ))
+                ) for r in self.repos
+            ))
+            results = [item for sublist in repo_results for item in sublist]
             return results[:top_k]
 
         return await self._search_namespace(

--- a/src/pipelines/retrieval.py
+++ b/src/pipelines/retrieval.py
@@ -177,16 +177,24 @@ class RetrievalPipeline:
 
         if ai_response.tool_calls:
             called_tools = set()
-            for tc in ai_response.tool_calls:
-                tool_name = tc["name"]
-                tool_args = tc["args"]
-                tool_id = tc["id"]
 
-                logger.info("  Tool call: %s(%s)", tool_name, tool_args)
+            # Helper to execute tool calls concurrently
+            async def _process_tool_call(tc: Dict[str, Any]) -> tuple[str, str, str, List[SourceRecord]]:
+                t_name = tc["name"]
+                t_args = tc["args"]
+                t_id = tc["id"]
+                logger.info("  Tool call: %s(%s)", t_name, t_args)
+                recs = await self._execute_tool(t_name, t_args, user_id, top_k)
+                return t_name, t_args, t_id, recs
 
-                records = await self._execute_tool(
-                    tool_name, tool_args, user_id, top_k,
-                )
+            import asyncio
+            # Execute all tool calls concurrently
+            results = await asyncio.gather(*(
+                _process_tool_call(tc) for tc in ai_response.tool_calls
+            ))
+
+            # Process results sequentially to safely extend shared state
+            for tool_name, tool_args, tool_id, records in results:
                 sources.extend(records)
 
                 # Build ToolMessage for the LLM


### PR DESCRIPTION
**💡 What:** Refactored LLM tool execution loops in `RetrievalPipeline` and `CodeRetrievalPipeline` to run independently spawned tool calls concurrently using `asyncio.gather`. Also applied concurrent searching across multiple repositories in `_search_symbols` and `_search_files`.
**🎯 Why:** Sequential tool execution caused significant compounding latency for complex questions where the LLM needs data from multiple domains (e.g. `search_profile` and `search_temporal` simultaneously) or when querying the default all-repository context. This bottleneck forced O(N) network latency for parallelizable tasks.
**📊 Impact:** Shifts I/O-bound retrieval from sequential to parallel latency. Expected to reduce end-to-end multi-domain retrieval time by >50% depending on the number of concurrent tool calls and repositories.
**🔬 Measurement:** View tracing output showing tool execution durations converging towards the slowest individual query, eliminating sequential delay accumulation. Evaluated syntactically with `ast.parse` and statically reviewed for functional correctness to avoid race conditions when appending to shared lists like `sources`.

---
*PR created automatically by Jules for task [963796135469649119](https://jules.google.com/task/963796135469649119) started by @ishaanxgupta*