### PR TITLE
⚡ Bolt: Optimize retrieval pipelines with concurrent tool execution

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Parallelize Tool Executions in Retrieval Pipelines
+**Learning:** Sequential execution of LLM tool calls in `RetrievalPipeline` and `CodeRetrievalPipeline` caused unnecessary blocking during query processing. Refactoring the loop to use `asyncio.gather` reduces latency.
+**Action:** When working with LLM responses that request multiple tool calls, evaluate if the calls are independent. If so, process them concurrently with `asyncio.gather` and then update shared state sequentially after awaiting the results to ensure thread safety and optimal performance.

--- a/src/pipelines/code_retrieval.py
+++ b/src/pipelines/code_retrieval.py
@@ -25,6 +25,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -37,7 +38,6 @@ from src.graph.code_graph_client import CodeGraphClient
 from src.scanner.code_store import CodeStore
 from src.schemas.code import (
     annotations_namespace,
-    directories_namespace,
     files_namespace,
     snippets_namespace,
     symbols_namespace,
@@ -375,11 +375,11 @@ class CodeRetrievalPipeline:
             turn_records: List[SourceRecord] = []
             only_read_tools = True
 
-            for tc in ai_response.tool_calls:
+
+
+            async def _process_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 t1 = _time.perf_counter()
                 records = await self._execute_tool(
                     tool_name, tool_args, repo=repo, top_k=top_k,
@@ -387,6 +387,14 @@ class CodeRetrievalPipeline:
                 )
                 tool_ms = (_time.perf_counter() - t1) * 1000
                 logger.info("  Tool: %s(%s) → %d results (%.0fms)", tool_name, tool_args, len(records), tool_ms)
+                return tc, records
+
+            tool_results = await asyncio.gather(*[_process_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for tc, records in tool_results:
+                tool_name = tc["name"]
+                tool_id = tc["id"]
+
                 turn_records.extend(records)
                 sources.extend(records)
 
@@ -471,17 +479,23 @@ class CodeRetrievalPipeline:
         if ai_response.tool_calls:
             yield json.dumps({"type": "status", "content": f"Running {len(ai_response.tool_calls)} search tool(s)..."}) + "\n"
             
-            for tc in ai_response.tool_calls:
+
+
+            async def _process_stream_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 logger.info("  Tool: %s(%s)", tool_name, tool_args)
 
                 records = await self._execute_tool(
                     tool_name, tool_args, repo=repo, top_k=top_k,
                     user_id=user_id,
                 )
+                return tc, records
+
+            tool_results = await asyncio.gather(*[_process_stream_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for tc, records in tool_results:
+                tool_id = tc["id"]
                 sources.extend(records)
 
                 tool_result_text = self._format_tool_results(records)

--- a/src/pipelines/retrieval.py
+++ b/src/pipelines/retrieval.py
@@ -20,8 +20,8 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import logging
-import os
 from typing import Any, Callable, Dict, List, Optional
 
 from dotenv import load_dotenv
@@ -176,17 +176,26 @@ class RetrievalPipeline:
         tool_messages: List[ToolMessage] = []
 
         if ai_response.tool_calls:
+
+
             called_tools = set()
-            for tc in ai_response.tool_calls:
+
+            async def _process_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
-                tool_id = tc["id"]
-
                 logger.info("  Tool call: %s(%s)", tool_name, tool_args)
 
                 records = await self._execute_tool(
                     tool_name, tool_args, user_id, top_k,
                 )
+                return tc, records
+
+            tool_results = await asyncio.gather(*[_process_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for tc, records in tool_results:
+                tool_name = tc["name"]
+                tool_id = tc["id"]
+
                 sources.extend(records)
 
                 # Build ToolMessage for the LLM
@@ -351,7 +360,7 @@ class RetrievalPipeline:
         top_k: int = 3,
     ) -> List[SourceRecord]:
         """Semantic search over temporal events in Neo4j."""
-        import asyncio
+
         from functools import partial
 
         loop = asyncio.get_running_loop()


### PR DESCRIPTION
💡 **What:** Refactored LLM tool execution to run concurrently rather than sequentially.
🎯 **Why:** Previously, if the LLM outputted multiple tool calls in a single turn, the pipeline executed them sequentially. For `get_file_context` or `search_symbols`, the waiting times accumulated linearly, unnecessarily blocking the final query resolution.
📊 **Impact:** Expecting significantly reduced response latency when multiple tool calls are used in an iteration.
🔬 **Measurement:** Verify query response time (or overall LLM ms tracking logs) when invoking queries that trigger complex, multi-tool analysis (e.g. `impact_analysis` followed by `get_file_context`).

---
*PR created automatically by Jules for task [2313201174069911635](https://jules.google.com/task/2313201174069911635) started by @ishaanxgupta*