### PR TITLE
Optimize LLM tool call execution and multi-repo searches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - [Optimize Code Retrieval LLM Tool Calling]
+**Learning:** Sequential loops for LLM tool executions (`ai_response.tool_calls`) and multi-repository searches (`results.extend()` over `self.repos`) create a bottleneck as multiple independent I/O-bound requests wait for each other.
+**Action:** Replace these sequential loops with `asyncio.gather` for concurrent execution, avoiding sequential bottlenecks, while ensuring the results are processed sequentially afterward to ensure safe appending to shared lists like `sources` and `tool_messages`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,0 @@
-
-## 2024-05-24 - [Optimize Code Retrieval LLM Tool Calling]
-**Learning:** Sequential loops for LLM tool executions (`ai_response.tool_calls`) and multi-repository searches (`results.extend()` over `self.repos`) create a bottleneck as multiple independent I/O-bound requests wait for each other.
-**Action:** Replace these sequential loops with `asyncio.gather` for concurrent execution, avoiding sequential bottlenecks, while ensuring the results are processed sequentially afterward to ensure safe appending to shared lists like `sources` and `tool_messages`.

--- a/src/pipelines/code_retrieval.py
+++ b/src/pipelines/code_retrieval.py
@@ -25,6 +25,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -37,7 +38,6 @@ from src.graph.code_graph_client import CodeGraphClient
 from src.scanner.code_store import CodeStore
 from src.schemas.code import (
     annotations_namespace,
-    directories_namespace,
     files_namespace,
     snippets_namespace,
     symbols_namespace,
@@ -375,11 +375,10 @@ class CodeRetrievalPipeline:
             turn_records: List[SourceRecord] = []
             only_read_tools = True
 
-            for tc in ai_response.tool_calls:
+            async def _process_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
                 tool_id = tc["id"]
-
                 t1 = _time.perf_counter()
                 records = await self._execute_tool(
                     tool_name, tool_args, repo=repo, top_k=top_k,
@@ -387,6 +386,11 @@ class CodeRetrievalPipeline:
                 )
                 tool_ms = (_time.perf_counter() - t1) * 1000
                 logger.info("  Tool: %s(%s) → %d results (%.0fms)", tool_name, tool_args, len(records), tool_ms)
+                return tool_name, tool_args, tool_id, records
+
+            tool_results = await asyncio.gather(*[_process_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for tool_name, tool_args, tool_id, records in tool_results:
                 turn_records.extend(records)
                 sources.extend(records)
 
@@ -471,17 +475,20 @@ class CodeRetrievalPipeline:
         if ai_response.tool_calls:
             yield json.dumps({"type": "status", "content": f"Running {len(ai_response.tool_calls)} search tool(s)..."}) + "\n"
             
-            for tc in ai_response.tool_calls:
+            async def _process_tool_call_stream(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
                 tool_id = tc["id"]
-
                 logger.info("  Tool: %s(%s)", tool_name, tool_args)
-
                 records = await self._execute_tool(
                     tool_name, tool_args, repo=repo, top_k=top_k,
                     user_id=user_id,
                 )
+                return tool_name, tool_args, tool_id, records
+
+            tool_results = await asyncio.gather(*[_process_tool_call_stream(tc) for tc in ai_response.tool_calls])
+
+            for tool_name, tool_args, tool_id, records in tool_results:
                 sources.extend(records)
 
                 tool_result_text = self._format_tool_results(records)
@@ -589,14 +596,17 @@ class CodeRetrievalPipeline:
     ) -> List[SourceRecord]:
         if not repo:
             logger.warning("search_symbols called without repo — searching all repos")
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            tasks = [
+                self._search_namespace(
                     namespace=symbols_namespace(self.org_id, r),
                     query=query,
                     domain="symbol",
                     top_k=top_k,
-                ))
+                )
+                for r in self.repos
+            ]
+            results_list = await asyncio.gather(*tasks)
+            results = [item for sublist in results_list for item in sublist]
             return results[:top_k]
 
         return await self._search_namespace(
@@ -612,14 +622,17 @@ class CodeRetrievalPipeline:
         self, query: str, repo: str, top_k: int = 10,
     ) -> List[SourceRecord]:
         if not repo:
-            results = []
-            for r in self.repos:
-                results.extend(await self._search_namespace(
+            tasks = [
+                self._search_namespace(
                     namespace=files_namespace(self.org_id, r),
                     query=query,
                     domain="file",
                     top_k=top_k,
-                ))
+                )
+                for r in self.repos
+            ]
+            results_list = await asyncio.gather(*tasks)
+            results = [item for sublist in results_list for item in sublist]
             return results[:top_k]
 
         return await self._search_namespace(

--- a/src/pipelines/retrieval.py
+++ b/src/pipelines/retrieval.py
@@ -20,8 +20,8 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import logging
-import os
 from typing import Any, Callable, Dict, List, Optional
 
 from dotenv import load_dotenv
@@ -177,16 +177,20 @@ class RetrievalPipeline:
 
         if ai_response.tool_calls:
             called_tools = set()
-            for tc in ai_response.tool_calls:
+
+            async def _process_tool_call(tc):
                 tool_name = tc["name"]
                 tool_args = tc["args"]
                 tool_id = tc["id"]
-
                 logger.info("  Tool call: %s(%s)", tool_name, tool_args)
-
                 records = await self._execute_tool(
                     tool_name, tool_args, user_id, top_k,
                 )
+                return tool_name, tool_args, tool_id, records
+
+            tool_results = await asyncio.gather(*[_process_tool_call(tc) for tc in ai_response.tool_calls])
+
+            for tool_name, tool_args, tool_id, records in tool_results:
                 sources.extend(records)
 
                 # Build ToolMessage for the LLM


### PR DESCRIPTION
💡 **What**: Optimized the execution of LLM tool calls and multi-repository searches in the `CodeRetrievalPipeline` and `RetrievalPipeline`. Replaced sequential `for` loops with concurrent execution via `asyncio.gather`, while carefully preserving the required sequential processing of the gathered results to avoid race conditions on shared lists (`sources`, `tool_messages`).

🎯 **Why**: When the LLM decided to invoke multiple tools (e.g., retrieving different files simultaneously) or when a query targeted multiple repositories, the pipeline previously awaited each I/O-bound operation sequentially. This created a significant bottleneck where independent network/database requests were waiting on each other.

📊 **Impact**: Reduces latency significantly during multi-tool execution and global searches. For example, executing 5 tool calls that take 200ms each will now take ~200ms in total instead of ~1000ms.

🔬 **Measurement**: Measure the total execution time of the `run` method in `RetrievalPipeline` and `CodeRetrievalPipeline` when the LLM makes multiple tool calls in a single turn, or when searching across multiple repositories without specifying a repo. Observe the timing logs to verify concurrent execution.

---
*PR created automatically by Jules for task [16276008160634690662](https://jules.google.com/task/16276008160634690662) started by @ishaanxgupta*