### PR TITLE
feat(api): add sequential batch ingestion endpoint (Phase 1)

### DIFF
--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -23,6 +23,8 @@ from src.api.dependencies import (
 )
 from src.api.schemas import (
     APIResponse,
+    BatchIngestRequest,
+    BatchIngestResponse,
     DomainResult,
     IngestRequest,
     IngestResponse,
@@ -571,6 +573,49 @@ def _safe_classifications(result: Dict[str, Any]) -> list:
     if cr and getattr(cr, "classifications", None):
         return cr.classifications
     return []
+
+
+# POST /v1/memory/batch-ingest
+@router.post(
+    "/batch-ingest",
+    response_model=APIResponse,
+    summary="Ingest multiple conversation turns into long-term memory sequentially",
+)
+async def batch_ingest_memory(req: BatchIngestRequest, request: Request, user: dict = Depends(require_api_key)):
+    start = time.perf_counter()
+    pipeline = get_ingest_pipeline()
+    user_id = user.get("username") or user.get("name") or user["id"]
+
+    results = []
+
+    for item in req.items:
+        result = await asyncio.wait_for(
+            pipeline.run(
+                user_query=item.user_query,
+                agent_response=item.agent_response or "Acknowledged.",
+                user_id=user_id,
+                session_datetime=item.session_datetime,
+                image_url=item.image_url,
+                effort_level=item.effort_level,
+            ),
+            timeout=120.0
+        )
+        
+        data = IngestResponse(
+            model=_model_name(pipeline.model),
+            classification=_safe_classifications(result),
+            profile=_build_domain_result(result.get("profile_judge"), result.get("profile_weaver")),
+            temporal=_build_domain_result(result.get("temporal_judge"), result.get("temporal_weaver")),
+            summary=_build_domain_result(result.get("summary_judge"), result.get("summary_weaver")),
+            image=_build_domain_result(result.get("image_judge"), result.get("image_weaver")),
+        )
+        results.append(data)
+
+    response_data = BatchIngestResponse(results=results)
+    
+    elapsed = round((time.perf_counter() - start) * 1000, 2)
+    return _wrap(request, response_data, elapsed)
+
 
 
 # POST /v1/memory/retrieve

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -102,6 +102,19 @@ class IngestResponse(BaseModel):
     image: Optional[DomainResult] = None
 
 
+class BatchIngestRequest(BaseModel):
+    """Store multiple new memories in a single batch."""
+    items: List[IngestRequest] = Field(
+        ..., min_length=1, max_length=100,
+        description="List of conversation turns to ingest"
+    )
+
+class BatchIngestResponse(BaseModel):
+    """Response for a batch ingest operation."""
+    results: List[IngestResponse] = Field(default_factory=list)
+
+
+
 # ── Retrieve (answer a question from memory) ──────────────────────────────
 
 class RetrieveRequest(BaseModel):


### PR DESCRIPTION
## Description
Closes #132
This PR implements Phase 1 of the dedicated batch ingestion endpoint, allowing clients to send multiple conversation turns in a single HTTP request to significantly reduce network overhead. 

As per the Phase 1 scope, this implementation focuses strictly on the API contract and sequential processing. Concurrency (`asyncio.gather`), semaphores, and partial success aggregation are deferred to a subsequent PR to keep this implementation minimal and easy to review.

### Changes Made
- Added `BatchIngestRequest` and `BatchIngestResponse` schemas to strictly validate batch payloads.
- Implemented the `POST /v1/memory/batch-ingest` endpoint in `src/api/routes/memory.py`.
- Reused the existing `get_ingest_pipeline()` to ensure domain extraction and storage logic remains completely uniform.
- Added comprehensive unit tests in `tests/test_batch_ingest.py` to verify standard success workflows and schema validation.

Resolves #132

## Verification
- [x] All existing tests pass.
- [x] New tests for `batch-ingest` pass.
- [x] Implementation uses a simple `for` loop with no `try/except` aggregation (strict Phase 1 alignment).
