### PR TITLE
Add durable control-plane state storage

### DIFF
--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -12,7 +12,7 @@ import hmac
 import logging
 import time
 from collections import defaultdict
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -20,15 +20,20 @@ from jose import JWTError, jwt
 
 from src.config import settings
 from src.database.api_key_store import APIKeyStore
+from src.database.control_plane_store import ControlPlaneStore
 from src.database.user_store import UserStore
 from src.pipelines.ingest import IngestPipeline
 from src.pipelines.retrieval import RetrievalPipeline
+
+if TYPE_CHECKING:
+    from src.pipelines.code_retrieval import CodeRetrievalPipeline
 
 logger = logging.getLogger("xmem.api.deps")
 
 # Initialize stores
 _user_store = UserStore()
 _api_key_store = APIKeyStore()
+_control_plane_store = ControlPlaneStore()
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Pipeline singletons (initialised at app startup via lifespan)
@@ -177,11 +182,17 @@ async def require_api_key(
     # 2. Check MongoDB for user-generated API keys
     key_doc = _api_key_store.validate_api_key(token)
     if key_doc:
+        if not _api_key_matches_request_context(key_doc, request):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="API key is not valid for this organization or project.",
+            )
         user_id = key_doc.get("user_id")
         if user_id:
             user = _user_store.get_user_by_id(user_id)
             if user:
                 user["id"] = str(user.pop("_id"))
+                request.state.api_key = key_doc
                 request.state.user = user
                 return user
 
@@ -199,6 +210,25 @@ async def require_api_key(
         status_code=status.HTTP_403_FORBIDDEN,
         detail="Invalid API key or token.",
     )
+
+
+def _api_key_matches_request_context(key_doc: dict, request: Request) -> bool:
+    """Enforce optional API-key org/project bindings from request context."""
+    org_id = key_doc.get("org_id")
+    project_id = key_doc.get("project_id")
+    if not org_id and not project_id:
+        return True
+
+    request_org = request.headers.get("x-org-id") or request.query_params.get("org_id")
+    request_project = (
+        request.headers.get("x-project-id") or request.query_params.get("project_id")
+    )
+
+    if org_id and request_org != org_id:
+        return False
+    if project_id and request_project != project_id:
+        return False
+    return True
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -306,19 +336,17 @@ class _SlidingWindowRateLimiter:
             return True, remaining
 
 
-_rate_limiter = _SlidingWindowRateLimiter(
-    max_requests=settings.rate_limit,
-    window_seconds=60,
-)
-
-
 async def enforce_rate_limit(
     request: Request,
     user: dict = Depends(require_api_key),
 ) -> dict:
     """Raise 429 if the caller has exceeded their per-minute quota."""
     identity = user.get("id", "anonymous")
-    allowed, remaining = await _rate_limiter.check(identity)
+    allowed, remaining = await _control_plane_store.check_rate_limit(
+        identity,
+        max_requests=settings.rate_limit,
+        window_seconds=60,
+    )
 
     request.state.rate_limit_remaining = remaining
 

--- a/src/api/routes/admin.py
+++ b/src/api/routes/admin.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel
 
 from src.config import settings
 from src.config.analytics import analytics
+from src.database.control_plane_store import ControlPlaneStore
 
 logger = logging.getLogger("xmem.api.admin")
 
@@ -46,6 +47,7 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 
 _admin_collection = None
 _admin_sessions: Dict[str, Dict[str, Any]] = {}  # token → {user, expires}
+_control_plane_store = ControlPlaneStore()
 
 
 def _get_admin_collection():
@@ -88,15 +90,13 @@ def _verify_admin_token(request: Request) -> Dict[str, Any]:
         if auth.startswith("Bearer "):
             token = auth[7:]
 
-    if not token or token not in _admin_sessions:
+    if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
-    session = _admin_sessions[token]
-    if datetime.now(timezone.utc) > session["expires"]:
-        del _admin_sessions[token]
+    user = _control_plane_store.get_admin_session(token)
+    if user is None:
         raise HTTPException(status_code=401, detail="Session expired")
-
-    return session["user"]
+    return user
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -114,12 +114,11 @@ async def admin_login(req: AdminLoginRequest):
     if not user:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
-    # Generate session token
-    token = hashlib.sha256(f"{req.username}{time.time()}".encode()).hexdigest()
-    _admin_sessions[token] = {
-        "user": {"username": user["username"], "role": user.get("role", "admin")},
-        "expires": datetime.now(timezone.utc) + timedelta(hours=24),
-    }
+    session = _control_plane_store.create_admin_session(
+        {"username": user["username"], "role": user.get("role", "admin")},
+        ttl_seconds=24 * 60 * 60,
+    )
+    token = session["token"]
 
     response = JSONResponse({"status": "ok", "token": token, "username": user["username"]})
     response.set_cookie(
@@ -135,8 +134,8 @@ async def admin_login(req: AdminLoginRequest):
 @router.post("/api/logout")
 async def admin_logout(request: Request):
     token = request.cookies.get("xmem_admin_token")
-    if token and token in _admin_sessions:
-        del _admin_sessions[token]
+    if token:
+        _control_plane_store.delete_admin_session(token)
     response = JSONResponse({"status": "ok"})
     response.delete_cookie("xmem_admin_token")
     return response
@@ -314,7 +313,7 @@ async def sse_system_logs(request: Request, user: dict = Depends(_verify_admin_t
 
                 if not line:
                     # journalctl exited — send error event and stop
-                    yield f"event: error\ndata: journalctl process exited\n\n"
+                    yield "event: error\ndata: journalctl process exited\n\n"
                     break
 
                 text = line.decode("utf-8", errors="replace").rstrip("\n")
@@ -386,8 +385,6 @@ async def analytics_summary(request: Request, user: dict = Depends(_verify_admin
         now = datetime.now(timezone.utc)
         last_24h = now - timedelta(hours=24)
         last_7d = now - timedelta(days=7)
-        last_30d = now - timedelta(days=30)
-
         # API call stats (last 24h)
         api_calls_24h = list(collection.aggregate([
             {"$match": {"event": "api_call", "ts": {"$gte": last_24h}}},

--- a/src/api/routes/api_keys.py
+++ b/src/api/routes/api_keys.py
@@ -22,6 +22,10 @@ api_key_store = APIKeyStore()
 class APIKeyCreateRequest(BaseModel):
     """Request model for creating a new API key."""
     name: str = Field(default="Default", description="Name for this API key")
+    scopes: List[str] = Field(default_factory=lambda: ["all"], description="Allowed scopes")
+    expires_at: Optional[datetime] = Field(None, description="Optional expiration timestamp")
+    org_id: Optional[str] = Field(None, description="Optional organization binding")
+    project_id: Optional[str] = Field(None, description="Optional project binding")
 
 
 class APIKeyCreateResponse(BaseModel):
@@ -33,6 +37,10 @@ class APIKeyCreateResponse(BaseModel):
     key_id: str = Field(..., description="ID of the API key for reference")
     name: str = Field(..., description="Name of the API key")
     created_at: datetime = Field(..., description="Creation timestamp")
+    scopes: List[str] = Field(default_factory=lambda: ["all"], description="Allowed scopes")
+    expires_at: Optional[datetime] = Field(None, description="Optional expiration timestamp")
+    org_id: Optional[str] = Field(None, description="Optional organization binding")
+    project_id: Optional[str] = Field(None, description="Optional project binding")
 
 
 class APIKeyResponse(BaseModel):
@@ -43,6 +51,10 @@ class APIKeyResponse(BaseModel):
     created_at: datetime = Field(..., description="Creation timestamp")
     last_used: Optional[datetime] = Field(None, description="Last usage timestamp")
     is_active: bool = Field(..., description="Whether the key is active")
+    scopes: List[str] = Field(default_factory=lambda: ["all"], description="Allowed scopes")
+    expires_at: Optional[datetime] = Field(None, description="Optional expiration timestamp")
+    org_id: Optional[str] = Field(None, description="Optional organization binding")
+    project_id: Optional[str] = Field(None, description="Optional project binding")
 
 
 class APIKeyUpdateRequest(BaseModel):
@@ -101,6 +113,10 @@ async def list_api_keys(
             created_at=key["created_at"],
             last_used=key.get("last_used"),
             is_active=key.get("is_active", True),
+            scopes=key.get("scopes", ["all"]),
+            expires_at=key.get("expires_at"),
+            org_id=key.get("org_id"),
+            project_id=key.get("project_id"),
         )
         for key in keys
     ]
@@ -121,6 +137,10 @@ async def create_api_key(
     result = api_key_store.create_api_key(
         user_id=current_user["id"],
         name=request.name,
+        scopes=request.scopes,
+        expires_at=request.expires_at,
+        org_id=request.org_id,
+        project_id=request.project_id,
     )
 
     return APIKeyCreateResponse(
@@ -128,6 +148,10 @@ async def create_api_key(
         key_id=result["key_id"],
         name=result["name"],
         created_at=result["created_at"],
+        scopes=result.get("scopes", ["all"]),
+        expires_at=result.get("expires_at"),
+        org_id=result.get("org_id"),
+        project_id=result.get("project_id"),
     )
 
 
@@ -167,6 +191,10 @@ async def update_api_key(
         created_at=updated_key["created_at"],
         last_used=updated_key.get("last_used"),
         is_active=updated_key.get("is_active", True),
+        scopes=updated_key.get("scopes", ["all"]),
+        expires_at=updated_key.get("expires_at"),
+        org_id=updated_key.get("org_id"),
+        project_id=updated_key.get("project_id"),
     )
 
 

--- a/src/api/routes/auth.py
+++ b/src/api/routes/auth.py
@@ -5,8 +5,8 @@ import string
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.responses import RedirectResponse
+from fastapi import APIRouter, Depends, Form, HTTPException, status
+from fastapi.responses import JSONResponse
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token
 from jose import JWTError, jwt
@@ -16,12 +16,14 @@ from src.api.dependencies import get_current_user, require_api_key, require_user
 from src.config import settings
 from src.database.user_store import UserStore
 from src.database.api_key_store import APIKeyStore
+from src.database.control_plane_store import ControlPlaneStore
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
 # Initialize stores
 user_store = UserStore()
 api_key_store = APIKeyStore()
+control_plane_store = ControlPlaneStore()
 
 # ═══════════════════════════════════════════════════════════════════════════
 # MCP OAuth Temp Token Store (in-memory with TTL)
@@ -41,39 +43,20 @@ def _generate_mcp_temp_token() -> str:
 
 def _create_mcp_temp_token(user_id: str) -> str:
     """Create and store a temporary token for the user."""
-    token = _generate_mcp_temp_token()
-    expires_at = datetime.utcnow() + timedelta(minutes=TEMP_TOKEN_TTL_MINUTES)
-
-    _mcp_temp_tokens[token] = {
-        "user_id": user_id,
-        "created_at": datetime.utcnow(),
-        "expires_at": expires_at,
-        "exchanged": False,
-    }
-
-    return token
+    created = control_plane_store.create_single_use_token(
+        "mcp_temp_token",
+        user_id=user_id,
+        prefix=TEMP_TOKEN_PREFIX,
+        ttl_seconds=TEMP_TOKEN_TTL_MINUTES * 60,
+    )
+    _mcp_temp_tokens[created["token"]] = {"expires_at": created["expires_at"]}
+    return created["token"]
 
 
 def _get_and_invalidate_mcp_token(token: str) -> Optional[str]:
     """Validate temp token and return user_id if valid, None otherwise."""
-    if token not in _mcp_temp_tokens:
-        return None
-
-    token_data = _mcp_temp_tokens[token]
-
-    # Check expiry
-    if datetime.utcnow() > token_data["expires_at"]:
-        del _mcp_temp_tokens[token]
-        return None
-
-    # Check if already exchanged
-    if token_data["exchanged"]:
-        return None
-
-    # Mark as exchanged and return user_id
-    user_id = token_data["user_id"]
-    del _mcp_temp_tokens[token]  # Single-use token
-    return user_id
+    _mcp_temp_tokens.pop(token, None)
+    return control_plane_store.consume_single_use_token("mcp_temp_token", token)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -83,27 +66,19 @@ _oauth_auth_codes: Dict[str, Dict[str, Any]] = {}
 
 def _generate_auth_code(user_id: str) -> str:
     """Generate a standard OAuth 2.0 authorization code."""
-    alphabet = string.ascii_letters + string.digits
-    code = "".join(secrets.choice(alphabet) for _ in range(32))
-    
-    _oauth_auth_codes[code] = {
-        "user_id": user_id,
-        "expires_at": datetime.utcnow() + timedelta(minutes=10)
-    }
-    return code
+    created = control_plane_store.create_single_use_token(
+        "oauth_auth_code",
+        user_id=user_id,
+        prefix="",
+        ttl_seconds=10 * 60,
+    )
+    _oauth_auth_codes[created["token"]] = {"expires_at": created["expires_at"]}
+    return created["token"]
 
 def _get_and_invalidate_auth_code(code: str) -> Optional[str]:
     """Validate auth code and return user_id if valid."""
-    if code not in _oauth_auth_codes:
-        return None
-        
-    data = _oauth_auth_codes[code]
-    del _oauth_auth_codes[code] # Single-use
-    
-    if datetime.utcnow() > data["expires_at"]:
-        return None
-        
-    return data["user_id"]
+    _oauth_auth_codes.pop(code, None)
+    return control_plane_store.consume_single_use_token("oauth_auth_code", code)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -534,9 +509,6 @@ async def oauth_approve(request: OAuthApproveRequest, current_user: dict = Depen
     code = _generate_auth_code(user_id)
     return OAuthApproveResponse(code=code)
 
-
-from fastapi import Form
-from fastapi.responses import JSONResponse
 
 @router.post("/oauth/token")
 async def oauth_token(

--- a/src/database/api_key_store.py
+++ b/src/database/api_key_store.py
@@ -6,11 +6,12 @@ import secrets
 import string
 import time
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from threading import RLock
 from typing import List, Optional, Dict, Any
 
 from src.config import settings
+from src.database.control_plane_store import _production_requires_durable_storage
 
 logger = logging.getLogger("xmem.database.api_key_store")
 
@@ -60,6 +61,10 @@ class APIKeyStore:
             logger.info("Connected to MongoDB for API key storage")
             self._ensure_indexes()
         except Exception as e:
+            if _production_requires_durable_storage():
+                raise RuntimeError(
+                    "Durable MongoDB storage is required for API keys in production"
+                ) from e
             logger.warning(f"MongoDB connection failed, using in-memory storage: {e}")
             self._connected = False
             self._in_memory = True
@@ -74,6 +79,7 @@ class APIKeyStore:
             self.api_keys.create_index([("user_id", ASCENDING)])
             self.api_keys.create_index([("key_hash", ASCENDING)], unique=True)
             self.api_keys.create_index([("is_active", ASCENDING)])
+            self.api_keys.create_index([("expires_at", ASCENDING)])
         except Exception as e:
             logger.warning(f"Failed to create indexes: {e}")
 
@@ -126,6 +132,10 @@ class APIKeyStore:
         self,
         user_id: str,
         name: str = "Default",
+        scopes: Optional[List[str]] = None,
+        expires_at: Optional[datetime] = None,
+        org_id: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a new API key for a user."""
         key = self._generate_api_key()
@@ -141,6 +151,10 @@ class APIKeyStore:
                 "key_hash": key_hash,
                 "key_prefix": key_prefix,
                 "name": name,
+                "scopes": scopes or ["all"],
+                "expires_at": expires_at,
+                "org_id": org_id,
+                "project_id": project_id,
                 "created_at": now,
                 "last_used": None,
                 "is_active": True,
@@ -152,6 +166,10 @@ class APIKeyStore:
                 "key_id": key_id,
                 "name": name,
                 "created_at": now,
+                "scopes": scopes or ["all"],
+                "expires_at": expires_at,
+                "org_id": org_id,
+                "project_id": project_id,
             }
 
         try:
@@ -160,6 +178,10 @@ class APIKeyStore:
                 "key_hash": key_hash,
                 "key_prefix": key_prefix,
                 "name": name,
+                "scopes": scopes or ["all"],
+                "expires_at": expires_at,
+                "org_id": org_id,
+                "project_id": project_id,
                 "created_at": now,
                 "last_used": None,
                 "is_active": True,
@@ -171,9 +193,17 @@ class APIKeyStore:
                 "key_id": str(result.inserted_id),
                 "name": name,
                 "created_at": now,
+                "scopes": scopes or ["all"],
+                "expires_at": expires_at,
+                "org_id": org_id,
+                "project_id": project_id,
             }
         except Exception as e:
             logger.error(f"Database error creating API key: {e}")
+            if _production_requires_durable_storage():
+                raise RuntimeError(
+                    "Durable MongoDB storage is required for API keys in production"
+                ) from e
             self._in_memory = True
             return self.create_api_key(user_id, name)
 
@@ -211,6 +241,8 @@ class APIKeyStore:
         if self._in_memory:
             for key_doc in _in_memory_api_keys.values():
                 if key_doc.get("key_hash") == key_hash and key_doc.get("is_active", True):
+                    if self._is_expired(key_doc.get("expires_at")):
+                        return None
                     key_doc["last_used"] = datetime.utcnow()
                     result = {**key_doc, "id": str(key_doc["_id"])}
                     result.pop("key_hash", None)
@@ -227,6 +259,8 @@ class APIKeyStore:
                 "is_active": True,
             })
             if key_doc:
+                if self._is_expired(key_doc.get("expires_at")):
+                    return None
                 now = datetime.utcnow()
                 self.api_keys.update_one(
                     {"_id": key_doc["_id"]},
@@ -244,6 +278,13 @@ class APIKeyStore:
         except Exception as e:
             logger.error(f"Database error validating API key: {e}")
             return None
+
+    def _is_expired(self, expires_at: Optional[datetime]) -> bool:
+        if expires_at is None:
+            return False
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        return expires_at <= datetime.now(timezone.utc)
 
     def revoke_api_key(self, user_id: str, key_id: str) -> bool:
         """Revoke (deactivate) an API key."""

--- a/src/database/control_plane_store.py
+++ b/src/database/control_plane_store.py
@@ -1,0 +1,248 @@
+"""Durable control-plane state for auth, sessions, and rate limits."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+import string
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+from src.config import settings
+
+logger = logging.getLogger("xmem.database.control_plane_store")
+
+_memory_records: Dict[str, Dict[str, Any]] = {}
+_memory_rate_limits: dict[str, list[float]] = defaultdict(list)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _production_requires_durable_storage() -> bool:
+    parsed = urlparse(settings.mongodb_uri)
+    host = parsed.hostname or ""
+    return settings.environment.lower() == "production" and host not in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    }
+
+
+def _random_token(prefix: str, length: int = 32) -> str:
+    alphabet = string.ascii_letters + string.digits
+    return prefix + "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+class ControlPlaneStore:
+    """MongoDB-backed store for short-lived control-plane state."""
+
+    def __init__(self, uri: str = None, database: str = None) -> None:
+        self._uri = uri or settings.mongodb_uri
+        self._database = database or settings.mongodb_database
+        self._client = None
+        self._db = None
+        self.records = None
+        self.rate_limits = None
+        self._connected = False
+        self._in_memory = False
+        self._try_connect()
+
+    def _try_connect(self) -> None:
+        try:
+            from pymongo import MongoClient
+
+            self._client = MongoClient(self._uri, serverSelectionTimeoutMS=5000)
+            self._client.admin.command("ping")
+            self._db = self._client[self._database]
+            self.records = self._db["control_plane_records"]
+            self.rate_limits = self._db["rate_limits"]
+            self._connected = True
+            self._in_memory = False
+            self._ensure_indexes()
+            logger.info("Connected to MongoDB for control-plane storage")
+        except Exception as exc:
+            if _production_requires_durable_storage():
+                raise RuntimeError(
+                    "Durable MongoDB storage is required in production"
+                ) from exc
+            logger.warning(
+                "MongoDB unavailable; using in-memory control-plane storage: %s", exc
+            )
+            self._connected = False
+            self._in_memory = True
+
+    def _ensure_indexes(self) -> None:
+        if not self._connected:
+            return
+        try:
+            from pymongo import ASCENDING
+
+            self.records.create_index(
+                [("record_type", ASCENDING), ("token_hash", ASCENDING)], unique=True
+            )
+            self.records.create_index([("expires_at", ASCENDING)], expireAfterSeconds=0)
+            self.rate_limits.create_index([("identity", ASCENDING)], unique=True)
+            self.rate_limits.create_index(
+                [("expires_at", ASCENDING)], expireAfterSeconds=0
+            )
+        except Exception as exc:
+            logger.warning("Failed to create control-plane indexes: %s", exc)
+
+    def create_single_use_token(
+        self,
+        record_type: str,
+        user_id: str,
+        prefix: str,
+        ttl_seconds: int,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        token = _random_token(prefix)
+        now = _now()
+        expires_at = now + timedelta(seconds=ttl_seconds)
+        record = {
+            "record_type": record_type,
+            "token_hash": _hash(token),
+            "user_id": user_id,
+            "metadata": metadata or {},
+            "created_at": now,
+            "expires_at": expires_at,
+            "exchanged": False,
+        }
+
+        if self._in_memory:
+            _memory_records[f"{record_type}:{record['token_hash']}"] = record
+        else:
+            self.records.insert_one(record)
+
+        return {"token": token, "expires_at": expires_at}
+
+    def consume_single_use_token(self, record_type: str, token: str) -> Optional[str]:
+        key = f"{record_type}:{_hash(token)}"
+        now = _now()
+
+        if self._in_memory:
+            record = _memory_records.pop(key, None)
+            if not record or record["expires_at"] <= now or record.get("exchanged"):
+                return None
+            return record["user_id"]
+
+        record = self.records.find_one_and_update(
+            {
+                "record_type": record_type,
+                "token_hash": _hash(token),
+                "exchanged": False,
+                "expires_at": {"$gt": now},
+            },
+            {"$set": {"exchanged": True, "exchanged_at": now}},
+        )
+        return record["user_id"] if record else None
+
+    def create_admin_session(
+        self, user: dict[str, Any], ttl_seconds: int
+    ) -> dict[str, Any]:
+        token = _random_token("adm-", 48)
+        now = _now()
+        expires_at = now + timedelta(seconds=ttl_seconds)
+        record = {
+            "record_type": "admin_session",
+            "token_hash": _hash(token),
+            "user": user,
+            "created_at": now,
+            "expires_at": expires_at,
+        }
+
+        if self._in_memory:
+            _memory_records[f"admin_session:{record['token_hash']}"] = record
+        else:
+            self.records.insert_one(record)
+
+        return {"token": token, "expires_at": expires_at}
+
+    def get_admin_session(self, token: str) -> Optional[dict[str, Any]]:
+        key = f"admin_session:{_hash(token)}"
+        now = _now()
+
+        if self._in_memory:
+            record = _memory_records.get(key)
+            if not record or record["expires_at"] <= now:
+                _memory_records.pop(key, None)
+                return None
+            return record["user"]
+
+        record = self.records.find_one(
+            {
+                "record_type": "admin_session",
+                "token_hash": _hash(token),
+                "expires_at": {"$gt": now},
+            }
+        )
+        return record["user"] if record else None
+
+    def delete_admin_session(self, token: str) -> None:
+        key = f"admin_session:{_hash(token)}"
+        if self._in_memory:
+            _memory_records.pop(key, None)
+            return
+        self.records.delete_one(
+            {"record_type": "admin_session", "token_hash": _hash(token)}
+        )
+
+    async def check_rate_limit(
+        self,
+        identity: str,
+        max_requests: int,
+        window_seconds: int,
+    ) -> tuple[bool, int]:
+        now = time.time()
+        cutoff = now - window_seconds
+
+        if self._in_memory:
+            timestamps = [hit for hit in _memory_rate_limits[identity] if hit > cutoff]
+            if len(timestamps) >= max_requests:
+                _memory_rate_limits[identity] = timestamps
+                return False, 0
+            timestamps.append(now)
+            _memory_rate_limits[identity] = timestamps
+            return True, max_requests - len(timestamps)
+
+        record = self.rate_limits.find_one({"identity": identity}) or {}
+        hits = [hit for hit in record.get("hits", []) if hit > cutoff]
+        if len(hits) >= max_requests:
+            self.rate_limits.update_one(
+                {"identity": identity},
+                {
+                    "$set": {
+                        "hits": hits,
+                        "expires_at": _now() + timedelta(seconds=window_seconds),
+                    }
+                },
+                upsert=True,
+            )
+            return False, 0
+
+        hits.append(now)
+        self.rate_limits.update_one(
+            {"identity": identity},
+            {
+                "$set": {
+                    "hits": hits,
+                    "expires_at": _now() + timedelta(seconds=window_seconds),
+                }
+            },
+            upsert=True,
+        )
+        return True, max(max_requests - len(hits), 0)
+
+    def close(self) -> None:
+        if self._client:
+            self._client.close()

--- a/tests/api/test_dependencies_and_routes.py
+++ b/tests/api/test_dependencies_and_routes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -76,6 +75,49 @@ def test_auth_dependency_rejects_missing_and_accepts_static_bearer_key(dependenc
     assert ok.json()["email"] == "static@xmem.ai"
     assert ok.headers["x-content-type-options"] == "nosniff"
     assert "x-request-id" in ok.headers
+
+
+def test_bound_api_key_requires_matching_request_context(dependency_app, monkeypatch):
+    class FakeApiKeyStore:
+        def validate_api_key(self, token):
+            if token != "xmem_bound":
+                return None
+            return {
+                "id": "key-1",
+                "user_id": "user-1",
+                "org_id": "org-1",
+                "project_id": "proj-1",
+                "scopes": ["memory:read"],
+            }
+
+    class FakeUserStore:
+        def get_user_by_id(self, user_id):
+            return {"_id": user_id, "email": "u@example.com", "name": "User"}
+
+    monkeypatch.setattr(deps, "_api_key_store", FakeApiKeyStore())
+    monkeypatch.setattr(deps, "_user_store", FakeUserStore())
+    client = TestClient(dependency_app)
+
+    wrong_context = client.get(
+        "/protected",
+        headers={
+            "Authorization": "Bearer xmem_bound",
+            "x-org-id": "other",
+            "x-project-id": "proj-1",
+        },
+    )
+    assert wrong_context.status_code == 403
+
+    ok = client.get(
+        "/protected",
+        headers={
+            "Authorization": "Bearer xmem_bound",
+            "x-org-id": "org-1",
+            "x-project-id": "proj-1",
+        },
+    )
+    assert ok.status_code == 200
+    assert ok.json()["user_id"] == "user-1"
 
 
 def test_dependency_injection_returns_configured_pipeline(dependency_app):

--- a/tests/unit/test_control_plane_store.py
+++ b/tests/unit/test_control_plane_store.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from src.database.control_plane_store import (
+    ControlPlaneStore,
+    _memory_rate_limits,
+    _memory_records,
+)
+
+
+def _force_memory(self):
+    self._connected = False
+    self._in_memory = True
+    self.records = None
+    self.rate_limits = None
+
+
+def test_single_use_tokens_are_durable_shape_and_single_use(monkeypatch):
+    _memory_records.clear()
+    monkeypatch.setattr(ControlPlaneStore, "_try_connect", _force_memory)
+    store = ControlPlaneStore()
+
+    created = store.create_single_use_token(
+        "oauth_auth_code",
+        user_id="user-1",
+        prefix="",
+        ttl_seconds=600,
+    )
+
+    assert (
+        store.consume_single_use_token("oauth_auth_code", created["token"]) == "user-1"
+    )
+    assert store.consume_single_use_token("oauth_auth_code", created["token"]) is None
+
+
+def test_admin_sessions_can_be_created_read_and_deleted(monkeypatch):
+    _memory_records.clear()
+    monkeypatch.setattr(ControlPlaneStore, "_try_connect", _force_memory)
+    store = ControlPlaneStore()
+
+    session = store.create_admin_session({"username": "admin"}, ttl_seconds=60)
+
+    assert store.get_admin_session(session["token"]) == {"username": "admin"}
+    store.delete_admin_session(session["token"])
+    assert store.get_admin_session(session["token"]) is None
+
+
+async def test_rate_limits_use_shared_store_shape(monkeypatch):
+    _memory_rate_limits.clear()
+    monkeypatch.setattr(ControlPlaneStore, "_try_connect", _force_memory)
+    store = ControlPlaneStore()
+
+    assert await store.check_rate_limit(
+        "user-1", max_requests=1, window_seconds=60
+    ) == (True, 0)
+    assert await store.check_rate_limit(
+        "user-1", max_requests=1, window_seconds=60
+    ) == (False, 0)

--- a/tests/unit/test_database_stores.py
+++ b/tests/unit/test_database_stores.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.database import api_key_store as api_key_store_module
 from src.database.api_key_store import APIKeyStore, _in_memory_api_keys
 from src.database.project_store import ProjectStore
 from src.database.models import TeamRole
@@ -10,6 +15,17 @@ def _force_api_key_memory(self):
     self._connected = False
     self._in_memory = True
     self.api_keys = None
+
+
+class _FailingApiKeyCollection:
+    def insert_one(self, _doc):
+        raise RuntimeError("database unavailable")
+
+
+def _force_api_key_connected_with_write_failure(self):
+    self._connected = True
+    self._in_memory = False
+    self.api_keys = _FailingApiKeyCollection()
 
 
 def _force_user_memory(self):
@@ -35,12 +51,48 @@ def test_api_key_store_creates_validates_updates_and_revokes_in_memory(monkeypat
     assert validated["user_id"] == "user-1"
     assert "key_hash" not in validated
 
+    scoped = store.create_api_key(
+        "user-1",
+        name="Project",
+        scopes=["memory:read"],
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        org_id="org-1",
+        project_id="proj-1",
+    )
+    scoped_doc = store.validate_api_key(scoped["key"])
+    assert scoped_doc["scopes"] == ["memory:read"]
+    assert scoped_doc["org_id"] == "org-1"
+    assert scoped_doc["project_id"] == "proj-1"
+
+    expired = store.create_api_key(
+        "user-1",
+        name="Expired",
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    assert store.validate_api_key(expired["key"]) is None
+
     assert store.update_api_key_name("user-1", created["key_id"], "Local Dev")
-    [listed] = store.get_user_api_keys("user-1")
+    listed = next(
+        key for key in store.get_user_api_keys("user-1") if key["id"] == created["key_id"]
+    )
     assert listed["name"] == "Local Dev"
 
     assert store.revoke_api_key("user-1", created["key_id"])
     assert store.validate_api_key(created["key"]) is None
+
+
+def test_api_key_store_refuses_write_fallback_in_remote_production(monkeypatch):
+    monkeypatch.setattr(APIKeyStore, "_try_connect", _force_api_key_connected_with_write_failure)
+    monkeypatch.setattr(api_key_store_module.settings, "environment", "production")
+    monkeypatch.setattr(
+        api_key_store_module.settings,
+        "mongodb_uri",
+        "mongodb://mongo.example:27017",
+    )
+
+    store = APIKeyStore()
+    with pytest.raises(RuntimeError, match="Durable MongoDB storage is required"):
+        store.create_api_key("user-1")
 
 
 def test_user_store_get_or_create_and_username_helpers_in_memory(monkeypatch):


### PR DESCRIPTION
## Summary
- add a Mongo-backed control-plane store for single-use OAuth/MCP tokens, admin sessions, and shared rate-limit counters
- extend API keys with scopes, expiry, org/project bindings, and production fail-fast behavior for durable storage
- wire auth/admin/rate-limit paths to durable state and add focused regression coverage

## Verification
- `uv run --extra dev python -m pytest tests/unit/test_control_plane_store.py tests/unit/test_database_stores.py tests/api/test_dependencies_and_routes.py`
- `uv run --extra dev ruff check src/database/control_plane_store.py src/database/api_key_store.py src/api/dependencies.py src/api/routes/auth.py src/api/routes/admin.py src/api/routes/api_keys.py tests/unit/test_control_plane_store.py tests/unit/test_database_stores.py tests/api/test_dependencies_and_routes.py`

/claim #161