### PR TITLE
Add durable background jobs for memory and scanner work

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -32,10 +32,13 @@ from src.api.routes.auth import router as auth_router
 from src.api.routes.code import router as code_router
 from src.api.routes.enterprise import router as enterprise_router
 from src.api.routes.health import router as health_router
+from src.api.routes.jobs import router as jobs_router
 from src.api.routes.memory import router as memory_router
+from src.api.routes.memory import run_batch_ingest_job, run_ingest_job
 from src.api.routes.memory import scrape_router as memory_scrape_router
 from src.api.routes.memory_graph import router as memory_graph_router
 from src.api.routes.scanner import router as scanner_router
+from src.api.routes.scanner import run_scanner_job, run_scanner_phase2_job
 from src.api.routes.telemetry import router as telemetry_router
 from src.api.schemas import APIResponse, StatusEnum
 from src.config import settings
@@ -99,7 +102,16 @@ def create_app() -> FastAPI:
         _set_event_loop(asyncio.get_running_loop())
 
         boot_task = asyncio.create_task(_boot_pipelines())
+        from src.jobs import init_jobs
+        init_jobs({
+            "memory.ingest": run_ingest_job,
+            "memory.batch_ingest": run_batch_ingest_job,
+            "scanner.scan": run_scanner_job,
+            "scanner.phase2": run_scanner_phase2_job,
+        })
         yield
+        from src.jobs import shutdown_jobs
+        await shutdown_jobs()
         await boot_task
         from src.api.dependencies import _ingest_pipeline, _retrieval_pipeline
         if _ingest_pipeline:
@@ -156,6 +168,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router)
     app.include_router(memory_scrape_router)
     app.include_router(memory_router)
+    app.include_router(jobs_router)
     app.include_router(memory_graph_router)
     app.include_router(code_router)
     app.include_router(scanner_router)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -36,6 +36,7 @@ from src.api.routes.jobs import router as jobs_router
 from src.api.routes.memory import router as memory_router
 from src.api.routes.memory import run_batch_ingest_job, run_ingest_job
 from src.api.routes.memory import scrape_router as memory_scrape_router
+from src.api.routes.memory import v2_router as memory_v2_router
 from src.api.routes.memory_graph import router as memory_graph_router
 from src.api.routes.scanner import router as scanner_router
 from src.api.routes.scanner import run_scanner_job, run_scanner_phase2_job
@@ -168,6 +169,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router)
     app.include_router(memory_scrape_router)
     app.include_router(memory_router)
+    app.include_router(memory_v2_router)
     app.include_router(jobs_router)
     app.include_router(memory_graph_router)
     app.include_router(code_router)
@@ -201,7 +203,7 @@ def create_app() -> FastAPI:
     async def sentry_debug():
         """Intentionally raises an error to verify Sentry is capturing exceptions."""
         try:
-            division_by_zero = 1 / 0
+            1 / 0
         except ZeroDivisionError as exc:
             from src.config.monitoring import capture_exception
             capture_exception(exc)

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -132,6 +132,11 @@ def is_ready() -> bool:
     return _pipelines_ready.is_set() and _init_error is None
 
 
+def get_owner_id(user: dict) -> str:
+    """Return the stable owner identifier used to scope user-owned records."""
+    return user.get("username") or user.get("name") or user["id"]
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Bearer-token authentication
 # ═══════════════════════════════════════════════════════════════════════════

--- a/src/api/routes/jobs.py
+++ b/src/api/routes/jobs.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from src.api.dependencies import enforce_rate_limit, require_api_key
+from src.api.dependencies import enforce_rate_limit, get_owner_id, require_api_key
 from src.api.schemas import APIResponse, JobStatusResponse, StatusEnum
 from src.jobs import get_job_store, serialize_job
 
@@ -25,13 +26,13 @@ async def get_job_status(
     user: dict = Depends(require_api_key),
 ):
     start = time.perf_counter()
-    owner_id = user.get("username") or user.get("name") or user["id"]
+    owner_id = get_owner_id(user)
     try:
         store = get_job_store()
     except RuntimeError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 
-    job = store.get(job_id, owner_id=owner_id)
+    job = await asyncio.to_thread(store.get, job_id, owner_id=owner_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found.")
 

--- a/src/api/routes/jobs.py
+++ b/src/api/routes/jobs.py
@@ -1,0 +1,46 @@
+"""Background job status routes."""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from src.api.dependencies import enforce_rate_limit, require_api_key
+from src.api.schemas import APIResponse, JobStatusResponse, StatusEnum
+from src.jobs import get_job_store, serialize_job
+
+router = APIRouter(
+    prefix="/v1/jobs",
+    tags=["jobs"],
+    dependencies=[Depends(enforce_rate_limit)],
+)
+
+
+@router.get("/{job_id}", summary="Get durable background job status")
+async def get_job_status(
+    job_id: str,
+    request: Request,
+    user: dict = Depends(require_api_key),
+):
+    start = time.perf_counter()
+    owner_id = user.get("username") or user.get("name") or user["id"]
+    try:
+        store = get_job_store()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    job = store.get(job_id, owner_id=owner_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found.")
+
+    data = JobStatusResponse(**serialize_job(job))
+    elapsed = round((time.perf_counter() - start) * 1000, 2)
+    body = APIResponse(
+        status=StatusEnum.OK,
+        request_id=getattr(request.state, "request_id", None),
+        data=data.model_dump(mode="json"),
+        elapsed_ms=elapsed,
+    )
+    return JSONResponse(content=body.model_dump(mode="json"))

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse
 from src.api.dependencies import (
     enforce_rate_limit,
     get_ingest_pipeline,
+    get_owner_id,
     get_retrieval_pipeline,
     require_api_key,
     require_ready,
@@ -600,8 +601,7 @@ async def ingest_memory(req: IngestRequest, request: Request, user: dict = Depen
     start = time.perf_counter()
     pipeline = get_ingest_pipeline()
 
-    # Get username from authenticated user
-    user_id = user.get("username") or user.get("name") or user["id"]
+    user_id = get_owner_id(user)
     payload = {
         "user_query": req.user_query,
         "agent_response": req.agent_response or "Acknowledged.",
@@ -613,7 +613,8 @@ async def ingest_memory(req: IngestRequest, request: Request, user: dict = Depen
 
     try:
         store = get_job_store()
-        job = store.enqueue(
+        job = await asyncio.to_thread(
+            store.enqueue,
             job_type="memory.ingest",
             owner_id=user_id,
             payload=payload,
@@ -662,7 +663,7 @@ def _safe_classifications(result: Dict[str, Any]) -> list:
 async def batch_ingest_memory(req: BatchIngestRequest, request: Request, user: dict = Depends(require_api_key)):
     start = time.perf_counter()
     pipeline = get_ingest_pipeline()
-    user_id = user.get("username") or user.get("name") or user["id"]
+    user_id = get_owner_id(user)
     payload = {
         "user_id": user_id,
         "items": [item.model_dump() for item in req.items],
@@ -670,7 +671,8 @@ async def batch_ingest_memory(req: BatchIngestRequest, request: Request, user: d
 
     try:
         store = get_job_store()
-        job = store.enqueue(
+        job = await asyncio.to_thread(
+            store.enqueue,
             job_type="memory.batch_ingest",
             owner_id=user_id,
             payload=payload,

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 from typing import Any, Dict, List
 
@@ -57,6 +58,12 @@ _ingest_semaphore = asyncio.Semaphore(5)
 router = APIRouter(
     prefix="/v1/memory",
     tags=["memory"],
+    dependencies=[Depends(require_ready), Depends(enforce_rate_limit)],
+)
+
+v2_router = APIRouter(
+    prefix="/v2/memory",
+    tags=["memory-v2"],
     dependencies=[Depends(require_ready), Depends(enforce_rate_limit)],
 )
 
@@ -189,8 +196,6 @@ async def run_batch_ingest_job(payload: Dict[str, Any]) -> Dict[str, Any]:
 # Launching Chromium from cold takes 3-5s. We keep a singleton alive and
 # reuse it across scrape requests. The browser is thread-safe when each
 # request uses its own BrowserContext.
-
-import threading
 
 _browser_lock = threading.Lock()
 _pw_instance = None
@@ -602,32 +607,18 @@ async def ingest_memory(req: IngestRequest, request: Request, user: dict = Depen
     pipeline = get_ingest_pipeline()
 
     user_id = get_owner_id(user)
-    payload = {
-        "user_query": req.user_query,
-        "agent_response": req.agent_response or "Acknowledged.",
-        "user_id": user_id,
-        "session_datetime": req.session_datetime,
-        "image_url": req.image_url,
-        "effort_level": req.effort_level,
-    }
-
-    try:
-        store = get_job_store()
-        job = await asyncio.to_thread(
-            store.enqueue,
-            job_type="memory.ingest",
-            owner_id=user_id,
-            payload=payload,
-        )
-        elapsed = round((time.perf_counter() - start) * 1000, 2)
-        return _job_enqueued_response(request, job, elapsed)
-    except RuntimeError:
-        logger.warning("Job store unavailable; falling back to synchronous ingest")
 
     try:
         async with _ingest_semaphore:
             result = await asyncio.wait_for(
-                pipeline.run(**payload),
+                pipeline.run(
+                    user_query=req.user_query,
+                    agent_response=req.agent_response or "Acknowledged.",
+                    user_id=user_id,
+                    session_datetime=req.session_datetime,
+                    image_url=req.image_url,
+                    effort_level=req.effort_level,
+                ),
                 timeout=120.0
             )
         data = IngestResponse(
@@ -664,24 +655,6 @@ async def batch_ingest_memory(req: BatchIngestRequest, request: Request, user: d
     start = time.perf_counter()
     pipeline = get_ingest_pipeline()
     user_id = get_owner_id(user)
-    payload = {
-        "user_id": user_id,
-        "items": [item.model_dump() for item in req.items],
-    }
-
-    try:
-        store = get_job_store()
-        job = await asyncio.to_thread(
-            store.enqueue,
-            job_type="memory.batch_ingest",
-            owner_id=user_id,
-            payload=payload,
-            timeout_seconds=120.0 * max(len(req.items), 1),
-        )
-        elapsed = round((time.perf_counter() - start) * 1000, 2)
-        return _job_enqueued_response(request, job, elapsed)
-    except RuntimeError:
-        logger.warning("Job store unavailable; falling back to synchronous batch ingest")
 
     results = []
 
@@ -712,6 +685,71 @@ async def batch_ingest_memory(req: BatchIngestRequest, request: Request, user: d
     
     elapsed = round((time.perf_counter() - start) * 1000, 2)
     return _wrap(request, response_data, elapsed)
+
+
+@v2_router.post(
+    "/ingest",
+    response_model=APIResponse,
+    summary="Queue a conversation turn for durable background memory ingest",
+)
+async def enqueue_ingest_memory(req: IngestRequest, request: Request, user: dict = Depends(require_api_key)):
+    start = time.perf_counter()
+    user_id = get_owner_id(user)
+    payload = {
+        "user_query": req.user_query,
+        "agent_response": req.agent_response or "Acknowledged.",
+        "user_id": user_id,
+        "session_datetime": req.session_datetime,
+        "image_url": req.image_url,
+        "effort_level": req.effort_level,
+    }
+
+    try:
+        store = get_job_store()
+        job = await asyncio.to_thread(
+            store.enqueue,
+            job_type="memory.ingest",
+            owner_id=user_id,
+            payload=payload,
+        )
+    except RuntimeError as exc:
+        elapsed = round((time.perf_counter() - start) * 1000, 2)
+        logger.warning("Job store unavailable for v2 memory ingest: %s", exc)
+        return _error(request, str(exc), 503, elapsed)
+
+    elapsed = round((time.perf_counter() - start) * 1000, 2)
+    return _job_enqueued_response(request, job, elapsed)
+
+
+@v2_router.post(
+    "/batch-ingest",
+    response_model=APIResponse,
+    summary="Queue multiple conversation turns for durable background memory ingest",
+)
+async def enqueue_batch_ingest_memory(req: BatchIngestRequest, request: Request, user: dict = Depends(require_api_key)):
+    start = time.perf_counter()
+    user_id = get_owner_id(user)
+    payload = {
+        "user_id": user_id,
+        "items": [item.model_dump() for item in req.items],
+    }
+
+    try:
+        store = get_job_store()
+        job = await asyncio.to_thread(
+            store.enqueue,
+            job_type="memory.batch_ingest",
+            owner_id=user_id,
+            payload=payload,
+            timeout_seconds=120.0 * max(len(req.items), 1),
+        )
+    except RuntimeError as exc:
+        elapsed = round((time.perf_counter() - start) * 1000, 2)
+        logger.warning("Job store unavailable for v2 memory batch ingest: %s", exc)
+        return _error(request, str(exc), 503, elapsed)
+
+    elapsed = round((time.perf_counter() - start) * 1000, 2)
+    return _job_enqueued_response(request, job, elapsed)
 
 
 

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -28,6 +28,7 @@ from src.api.schemas import (
     DomainResult,
     IngestRequest,
     IngestResponse,
+    JobEnqueueResponse,
     OperationDetail,
     RetrieveRequest,
     RetrieveResponse,
@@ -40,6 +41,7 @@ from src.api.schemas import (
     StatusEnum,
     WeaverSummary,
 )
+from src.jobs import get_job_store
 from src.pipelines.retrieval import RetrievalPipeline
 
 from bs4 import BeautifulSoup
@@ -108,6 +110,17 @@ def _error(request: Request, detail: str, code: int, elapsed_ms: float = 0) -> J
     return JSONResponse(content=body.model_dump(), status_code=code)
 
 
+def _job_enqueued_response(request: Request, job: Dict[str, Any], elapsed_ms: float) -> JSONResponse:
+    data = JobEnqueueResponse(
+        job_id=job["job_id"],
+        job_type=job["job_type"],
+        status=job["status"],
+        idempotency_key=job["idempotency_key"],
+        status_url=f"/v1/jobs/{job['job_id']}",
+    )
+    return _wrap(request, data, elapsed_ms)
+
+
 def _detect_chat_provider(*urls: str) -> str:
     for url in urls:
         lowered = (url or "").lower()
@@ -138,6 +151,37 @@ def _chat_share_error_message(result: Dict[str, Any]) -> str:
 
 async def _render_chat_share(url: str) -> tuple[str, str]:
     return await asyncio.to_thread(_render_chat_share_sync, url)
+
+
+async def run_ingest_job(payload: Dict[str, Any]) -> Dict[str, Any]:
+    pipeline = get_ingest_pipeline()
+    result = await asyncio.wait_for(
+        pipeline.run(
+            user_query=payload["user_query"],
+            agent_response=payload.get("agent_response") or "Acknowledged.",
+            user_id=payload["user_id"],
+            session_datetime=payload.get("session_datetime", ""),
+            image_url=payload.get("image_url", ""),
+            effort_level=payload.get("effort_level", "low"),
+        ),
+        timeout=120.0,
+    )
+    data = IngestResponse(
+        model=_model_name(pipeline.model),
+        classification=_safe_classifications(result),
+        profile=_build_domain_result(result.get("profile_judge"), result.get("profile_weaver")),
+        temporal=_build_domain_result(result.get("temporal_judge"), result.get("temporal_weaver")),
+        summary=_build_domain_result(result.get("summary_judge"), result.get("summary_weaver")),
+        image=_build_domain_result(result.get("image_judge"), result.get("image_weaver")),
+    )
+    return data.model_dump()
+
+
+async def run_batch_ingest_job(payload: Dict[str, Any]) -> Dict[str, Any]:
+    results = []
+    for item in payload["items"]:
+        results.append(await run_ingest_job({**item, "user_id": payload["user_id"]}))
+    return BatchIngestResponse(results=[IngestResponse(**result) for result in results]).model_dump()
 
 
 # ── Warm browser pool ──────────────────────────────────────────────────────
@@ -558,18 +602,31 @@ async def ingest_memory(req: IngestRequest, request: Request, user: dict = Depen
 
     # Get username from authenticated user
     user_id = user.get("username") or user.get("name") or user["id"]
+    payload = {
+        "user_query": req.user_query,
+        "agent_response": req.agent_response or "Acknowledged.",
+        "user_id": user_id,
+        "session_datetime": req.session_datetime,
+        "image_url": req.image_url,
+        "effort_level": req.effort_level,
+    }
+
+    try:
+        store = get_job_store()
+        job = store.enqueue(
+            job_type="memory.ingest",
+            owner_id=user_id,
+            payload=payload,
+        )
+        elapsed = round((time.perf_counter() - start) * 1000, 2)
+        return _job_enqueued_response(request, job, elapsed)
+    except RuntimeError:
+        logger.warning("Job store unavailable; falling back to synchronous ingest")
 
     try:
         async with _ingest_semaphore:
             result = await asyncio.wait_for(
-                pipeline.run(
-                    user_query=req.user_query,
-                    agent_response=req.agent_response or "Acknowledged.",
-                    user_id=user_id,
-                    session_datetime=req.session_datetime,
-                    image_url=req.image_url,
-                    effort_level=req.effort_level,
-                ),
+                pipeline.run(**payload),
                 timeout=120.0
             )
         data = IngestResponse(
@@ -606,6 +663,23 @@ async def batch_ingest_memory(req: BatchIngestRequest, request: Request, user: d
     start = time.perf_counter()
     pipeline = get_ingest_pipeline()
     user_id = user.get("username") or user.get("name") or user["id"]
+    payload = {
+        "user_id": user_id,
+        "items": [item.model_dump() for item in req.items],
+    }
+
+    try:
+        store = get_job_store()
+        job = store.enqueue(
+            job_type="memory.batch_ingest",
+            owner_id=user_id,
+            payload=payload,
+            timeout_seconds=120.0 * max(len(req.items), 1),
+        )
+        elapsed = round((time.perf_counter() - start) * 1000, 2)
+        return _job_enqueued_response(request, job, elapsed)
+    except RuntimeError:
+        logger.warning("Job store unavailable; falling back to synchronous batch ingest")
 
     results = []
 

--- a/src/api/routes/memory.py
+++ b/src/api/routes/memory.py
@@ -43,6 +43,7 @@ from src.api.schemas import (
     StatusEnum,
     WeaverSummary,
 )
+from src.config import settings
 from src.jobs import get_job_store
 from src.pipelines.retrieval import RetrievalPipeline
 
@@ -172,7 +173,7 @@ async def run_ingest_job(payload: Dict[str, Any]) -> Dict[str, Any]:
             image_url=payload.get("image_url", ""),
             effort_level=payload.get("effort_level", "low"),
         ),
-        timeout=120.0,
+        timeout=settings.job_timeout_seconds,
     )
     data = IngestResponse(
         model=_model_name(pipeline.model),
@@ -741,7 +742,10 @@ async def enqueue_batch_ingest_memory(req: BatchIngestRequest, request: Request,
             job_type="memory.batch_ingest",
             owner_id=user_id,
             payload=payload,
-            timeout_seconds=120.0 * max(len(req.items), 1),
+            timeout_seconds=min(
+                settings.job_timeout_seconds * max(len(req.items), 1),
+                settings.job_timeout_seconds * 10,
+            ),
         )
     except RuntimeError as exc:
         elapsed = round((time.perf_counter() - start) * 1000, 2)

--- a/src/api/routes/scanner.py
+++ b/src/api/routes/scanner.py
@@ -37,7 +37,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
-from src.api.dependencies import require_api_key
+from src.api.dependencies import get_owner_id, require_api_key
 from src.config import settings
 from src.jobs import get_job_store
 
@@ -611,7 +611,7 @@ async def run_scanner_phase2_job(payload: Dict[str, Any]) -> Dict[str, Any]:
     return {"scanner_job_id": payload["scanner_job_id"]}
 
 
-def _enqueue_or_start_scanner_job(
+async def _enqueue_or_start_scanner_job(
     *,
     job_type: str,
     scanner_job_id: str,
@@ -634,7 +634,9 @@ def _enqueue_or_start_scanner_job(
         "force_full": force_full,
     }
     try:
-        job = get_job_store().enqueue(
+        store = get_job_store()
+        job = await asyncio.to_thread(
+            store.enqueue,
             job_type=job_type,
             owner_id=username,
             payload=payload,
@@ -798,7 +800,7 @@ async def resume_scan(req: ResumeScanRequest, user: dict = Depends(require_api_k
             branch=branch, url=url, phase1_status="running", phase2_status="pending",
             started_at=started_at, error=None,
         )
-        queue_job_id = _enqueue_or_start_scanner_job(
+        queue_job_id = await _enqueue_or_start_scanner_job(
             job_type="scanner.scan",
             scanner_job_id=job_id,
             username=req.username,
@@ -822,7 +824,7 @@ async def resume_scan(req: ResumeScanRequest, user: dict = Depends(require_api_k
         branch=branch, url=url, phase1_status="complete", phase2_status="running",
         started_at=started_at, error=None,
     )
-    queue_job_id = _enqueue_or_start_scanner_job(
+    queue_job_id = await _enqueue_or_start_scanner_job(
         job_type="scanner.phase2",
         scanner_job_id=job_id,
         username=req.username,
@@ -850,7 +852,7 @@ async def start_scan(req: ScanRequest, user: dict = Depends(require_api_key)):
             {"status": "error", "error": str(e)}, status_code=400,
         )
 
-    username = user.get("username") or user.get("name") or user["id"]
+    username = get_owner_id(user)
     job_id = f"{username}:{org}:{repo}"
     store = _get_code_store()
 
@@ -933,7 +935,7 @@ async def start_scan(req: ScanRequest, user: dict = Depends(require_api_key)):
     store.upsert_user_repo_entry(username, org, repo, branch)
 
     if phase2_only:
-        queue_job_id = _enqueue_or_start_scanner_job(
+        queue_job_id = await _enqueue_or_start_scanner_job(
             job_type="scanner.phase2",
             scanner_job_id=job_id,
             username=username,
@@ -955,7 +957,7 @@ async def start_scan(req: ScanRequest, user: dict = Depends(require_api_key)):
             "phase2_status": "running",
         })
 
-    queue_job_id = _enqueue_or_start_scanner_job(
+    queue_job_id = await _enqueue_or_start_scanner_job(
         job_type="scanner.scan",
         scanner_job_id=job_id,
         username=username,

--- a/src/api/routes/scanner.py
+++ b/src/api/routes/scanner.py
@@ -642,6 +642,7 @@ async def _enqueue_or_start_scanner_job(
             payload=payload,
             idempotency_key=f"{job_type}:{scanner_job_id}",
             timeout_seconds=settings.job_timeout_seconds * 5,
+            lease_seconds=settings.job_timeout_seconds * 5,
         )
         return job["job_id"]
     except RuntimeError:

--- a/src/api/routes/scanner.py
+++ b/src/api/routes/scanner.py
@@ -39,6 +39,7 @@ from pydantic import BaseModel, Field
 
 from src.api.dependencies import require_api_key
 from src.config import settings
+from src.jobs import get_job_store
 
 logger = logging.getLogger("xmem.api.routes.scanner")
 
@@ -583,6 +584,77 @@ async def _run_phase2_pipeline_only(
 
     _cleanup_clone(org, repo)
 
+
+async def run_scanner_job(payload: Dict[str, Any]) -> Dict[str, Any]:
+    await _run_scan_pipeline(
+        payload["scanner_job_id"],
+        payload["username"],
+        payload["org"],
+        payload["repo"],
+        payload["url"],
+        payload["branch"],
+        payload.get("pat", ""),
+        payload.get("force_full", True),
+    )
+    return {"scanner_job_id": payload["scanner_job_id"]}
+
+
+async def run_scanner_phase2_job(payload: Dict[str, Any]) -> Dict[str, Any]:
+    await _run_phase2_pipeline_only(
+        payload["scanner_job_id"],
+        payload["username"],
+        payload["org"],
+        payload["repo"],
+        payload["url"],
+        payload["branch"],
+    )
+    return {"scanner_job_id": payload["scanner_job_id"]}
+
+
+def _enqueue_or_start_scanner_job(
+    *,
+    job_type: str,
+    scanner_job_id: str,
+    username: str,
+    org: str,
+    repo: str,
+    url: str,
+    branch: str,
+    pat: str = "",
+    force_full: bool = True,
+) -> Optional[str]:
+    payload = {
+        "scanner_job_id": scanner_job_id,
+        "username": username,
+        "org": org,
+        "repo": repo,
+        "url": url,
+        "branch": branch,
+        "pat": pat,
+        "force_full": force_full,
+    }
+    try:
+        job = get_job_store().enqueue(
+            job_type=job_type,
+            owner_id=username,
+            payload=payload,
+            idempotency_key=f"{job_type}:{scanner_job_id}",
+            timeout_seconds=settings.job_timeout_seconds * 5,
+        )
+        return job["job_id"]
+    except RuntimeError:
+        logger.warning("Job store unavailable; falling back to in-process scanner task")
+        if job_type == "scanner.phase2":
+            asyncio.create_task(
+                _run_phase2_pipeline_only(scanner_job_id, username, org, repo, url, branch),
+            )
+        else:
+            asyncio.create_task(
+                _run_scan_pipeline(scanner_job_id, username, org, repo, url, branch, pat, force_full),
+            )
+        return None
+
+
 @router.post(
     "/validate-url",
     summary="Validate a GitHub URL and check accessibility",
@@ -726,13 +798,20 @@ async def resume_scan(req: ResumeScanRequest, user: dict = Depends(require_api_k
             branch=branch, url=url, phase1_status="running", phase2_status="pending",
             started_at=started_at, error=None,
         )
-        asyncio.create_task(
-            _run_scan_pipeline(job_id, req.username, req.org_id, req.repo, url, branch, ""),
+        queue_job_id = _enqueue_or_start_scanner_job(
+            job_type="scanner.scan",
+            scanner_job_id=job_id,
+            username=req.username,
+            org=req.org_id,
+            repo=req.repo,
+            url=url,
+            branch=branch,
         )
         logger.info("Resumed Phase 1 for %s/%s", req.org_id, req.repo)
         return JSONResponse({
             "status": "ok",
             "message": "Scan resumed from Phase 1.",
+            "queue_job_id": queue_job_id,
             "phase1_status": "running",
             "phase2_status": "pending",
         })
@@ -743,13 +822,20 @@ async def resume_scan(req: ResumeScanRequest, user: dict = Depends(require_api_k
         branch=branch, url=url, phase1_status="complete", phase2_status="running",
         started_at=started_at, error=None,
     )
-    asyncio.create_task(
-        _run_phase2_pipeline_only(job_id, req.username, req.org_id, req.repo, url, branch),
+    queue_job_id = _enqueue_or_start_scanner_job(
+        job_type="scanner.phase2",
+        scanner_job_id=job_id,
+        username=req.username,
+        org=req.org_id,
+        repo=req.repo,
+        url=url,
+        branch=branch,
     )
     logger.info("Resumed Phase 2 for %s/%s", req.org_id, req.repo)
     return JSONResponse({
         "status": "ok",
         "message": "Scan resumed from Phase 2.",
+        "queue_job_id": queue_job_id,
         "phase1_status": "complete",
         "phase2_status": "running",
     })
@@ -847,14 +933,19 @@ async def start_scan(req: ScanRequest, user: dict = Depends(require_api_key)):
     store.upsert_user_repo_entry(username, org, repo, branch)
 
     if phase2_only:
-        asyncio.create_task(
-            _run_phase2_pipeline_only(
-                job_id, username, org, repo, clone_url, branch,
-            ),
+        queue_job_id = _enqueue_or_start_scanner_job(
+            job_type="scanner.phase2",
+            scanner_job_id=job_id,
+            username=username,
+            org=org,
+            repo=repo,
+            url=clone_url,
+            branch=branch,
         )
         return JSONResponse({
             "status": "ok",
             "job_id": job_id,
+            "queue_job_id": queue_job_id,
             "org": org,
             "repo": repo,
             "reused": False,
@@ -864,15 +955,22 @@ async def start_scan(req: ScanRequest, user: dict = Depends(require_api_key)):
             "phase2_status": "running",
         })
 
-    asyncio.create_task(
-        _run_scan_pipeline(
-            job_id, username, org, repo, clone_url, branch, req.pat, req.force_full,
-        ),
+    queue_job_id = _enqueue_or_start_scanner_job(
+        job_type="scanner.scan",
+        scanner_job_id=job_id,
+        username=username,
+        org=org,
+        repo=repo,
+        url=clone_url,
+        branch=branch,
+        pat=req.pat,
+        force_full=req.force_full,
     )
 
     return JSONResponse({
         "status": "ok",
         "job_id": job_id,
+        "queue_job_id": queue_job_id,
         "org": org,
         "repo": repo,
         "reused": False,

--- a/src/api/routes/scanner.py
+++ b/src/api/routes/scanner.py
@@ -46,6 +46,7 @@ logger = logging.getLogger("xmem.api.routes.scanner")
 router = APIRouter(prefix="/v1/scanner", tags=["scanner"])
 
 _code_store_singleton: Any = None
+_scanner_pat_refs: Dict[str, str] = {}
 
 
 def _get_code_store():
@@ -58,6 +59,25 @@ def _get_code_store():
             database=settings.mongodb_database,
         )
     return _code_store_singleton
+
+
+def _stash_scanner_pat(scanner_job_id: str, pat: str) -> bool:
+    if not pat:
+        return False
+    _scanner_pat_refs[scanner_job_id] = pat
+    return True
+
+
+def _resolve_scanner_pat(payload: Dict[str, Any]) -> str:
+    if not payload.get("requires_pat"):
+        return ""
+    pat = _scanner_pat_refs.get(payload["scanner_job_id"])
+    if pat is None:
+        raise RuntimeError(
+            "GitHub credential is no longer available for this scanner job; "
+            "please start the scan again."
+        )
+    return pat
 
 
 # â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
@@ -586,6 +606,7 @@ async def _run_phase2_pipeline_only(
 
 
 async def run_scanner_job(payload: Dict[str, Any]) -> Dict[str, Any]:
+    pat = _resolve_scanner_pat(payload)
     await _run_scan_pipeline(
         payload["scanner_job_id"],
         payload["username"],
@@ -593,7 +614,7 @@ async def run_scanner_job(payload: Dict[str, Any]) -> Dict[str, Any]:
         payload["repo"],
         payload["url"],
         payload["branch"],
-        payload.get("pat", ""),
+        pat,
         payload.get("force_full", True),
     )
     return {"scanner_job_id": payload["scanner_job_id"]}
@@ -623,6 +644,7 @@ async def _enqueue_or_start_scanner_job(
     pat: str = "",
     force_full: bool = True,
 ) -> Optional[str]:
+    requires_pat = _stash_scanner_pat(scanner_job_id, pat)
     payload = {
         "scanner_job_id": scanner_job_id,
         "username": username,
@@ -630,7 +652,7 @@ async def _enqueue_or_start_scanner_job(
         "repo": repo,
         "url": url,
         "branch": branch,
-        "pat": pat,
+        "requires_pat": requires_pat,
         "force_full": force_full,
     }
     try:

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -114,6 +114,31 @@ class BatchIngestResponse(BaseModel):
     results: List[IngestResponse] = Field(default_factory=list)
 
 
+class JobEnqueueResponse(BaseModel):
+    """Response returned when long-running work is accepted by the job queue."""
+    job_id: str
+    job_type: str
+    status: str
+    idempotency_key: str
+    status_url: str
+
+
+class JobStatusResponse(BaseModel):
+    """Public state for a background job."""
+    job_id: str
+    job_type: str
+    status: str
+    retry_count: int = 0
+    max_retries: int = 0
+    timeout_seconds: float = 0.0
+    error: Optional[str] = None
+    result: Optional[Any] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+
+
 
 # ── Retrieve (answer a question from memory) ──────────────────────────────
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -208,6 +208,30 @@ class Settings(BaseSettings):
         default=60,
         description="Rate limit (requests per minute)"
     )
+    job_worker_enabled: bool = Field(
+        default=True,
+        description="Enable durable background job queue worker"
+    )
+    job_poll_interval_seconds: float = Field(
+        default=1.0,
+        description="Seconds between job queue polls when idle"
+    )
+    job_timeout_seconds: float = Field(
+        default=120.0,
+        description="Default timeout for background jobs"
+    )
+    job_max_retries: int = Field(
+        default=3,
+        description="Default retry attempts before moving a job to dead-letter"
+    )
+    job_retry_backoff_seconds: float = Field(
+        default=5.0,
+        description="Initial exponential backoff delay for job retries"
+    )
+    job_lease_seconds: float = Field(
+        default=300.0,
+        description="Seconds before a running job lease is considered stale"
+    )
 
     # Scanner dashboard — heuristic pre-scan estimates (tunable)
     scanner_estimate_phase1_base_seconds: float = Field(

--- a/src/jobs.py
+++ b/src/jobs.py
@@ -1,0 +1,290 @@
+"""Durable background jobs for request-time memory work."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from pymongo import ASCENDING, ReturnDocument
+
+from src.config import settings
+
+logger = logging.getLogger("xmem.jobs")
+
+
+class JobStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    DEAD_LETTER = "dead_letter"
+
+
+JobHandler = Callable[[Dict[str, Any]], Awaitable[Any]]
+
+
+class JobStore:
+    """Mongo-backed durable queue with deterministic idempotency keys."""
+
+    def __init__(self, uri: str | None = None, database: str | None = None) -> None:
+        from pymongo import MongoClient
+
+        self._client = MongoClient(uri or settings.mongodb_uri, serverSelectionTimeoutMS=5000)
+        self._client.admin.command("ping")
+        self._db = self._client[database or settings.mongodb_database]
+        self.jobs = self._db["jobs"]
+        self.dead_letters = self._db["job_dead_letters"]
+        self._ensure_indexes()
+
+    def _ensure_indexes(self) -> None:
+        self.jobs.create_index([("idempotency_key", ASCENDING)], unique=True, sparse=True)
+        self.jobs.create_index([("status", ASCENDING), ("run_after", ASCENDING)])
+        self.jobs.create_index([("owner_id", ASCENDING), ("created_at", ASCENDING)])
+        self.dead_letters.create_index([("job_id", ASCENDING)], unique=True)
+
+    @staticmethod
+    def make_idempotency_key(job_type: str, owner_id: str, payload: Dict[str, Any]) -> str:
+        stable = repr(_stable(payload)).encode("utf-8")
+        digest = hashlib.sha256(stable).hexdigest()
+        return f"{job_type}:{owner_id}:{digest}"
+
+    def enqueue(
+        self,
+        *,
+        job_type: str,
+        owner_id: str,
+        payload: Dict[str, Any],
+        idempotency_key: str | None = None,
+        timeout_seconds: float | None = None,
+        max_retries: int | None = None,
+    ) -> Dict[str, Any]:
+        now = _now()
+        job_id = str(uuid.uuid4())
+        key = idempotency_key or self.make_idempotency_key(job_type, owner_id, payload)
+        doc = {
+            "job_id": job_id,
+            "job_type": job_type,
+            "owner_id": owner_id,
+            "payload": payload,
+            "idempotency_key": key,
+            "status": JobStatus.PENDING.value,
+            "retry_count": 0,
+            "max_retries": settings.job_max_retries if max_retries is None else max_retries,
+            "timeout_seconds": settings.job_timeout_seconds if timeout_seconds is None else timeout_seconds,
+            "error": None,
+            "result": None,
+            "run_after": now,
+            "created_at": now,
+            "updated_at": now,
+            "started_at": None,
+            "finished_at": None,
+        }
+
+        existing = self.jobs.find_one({"idempotency_key": key})
+        if existing:
+            return existing
+
+        try:
+            self.jobs.insert_one(doc)
+            return doc
+        except Exception:
+            existing = self.jobs.find_one({"idempotency_key": key})
+            if existing:
+                return existing
+            raise
+
+    def get(self, job_id: str, owner_id: str | None = None) -> Optional[Dict[str, Any]]:
+        query: Dict[str, Any] = {"job_id": job_id}
+        if owner_id is not None:
+            query["owner_id"] = owner_id
+        return self.jobs.find_one(query, {"_id": False})
+
+    def claim_next(self, worker_id: str) -> Optional[Dict[str, Any]]:
+        now = _now()
+        stale_before = now - timedelta(seconds=settings.job_lease_seconds)
+        query = {
+            "$or": [
+                {"status": JobStatus.PENDING.value, "run_after": {"$lte": now}},
+                {
+                    "status": JobStatus.RUNNING.value,
+                    "started_at": {"$lt": stale_before},
+                },
+            ]
+        }
+        update = {
+            "$set": {
+                "status": JobStatus.RUNNING.value,
+                "worker_id": worker_id,
+                "started_at": now,
+                "updated_at": now,
+            }
+        }
+        return self.jobs.find_one_and_update(
+            query,
+            update,
+            sort=[("run_after", ASCENDING), ("created_at", ASCENDING)],
+            return_document=ReturnDocument.AFTER,
+        )
+
+    def succeed(self, job_id: str, result: Any) -> None:
+        now = _now()
+        self.jobs.update_one(
+            {"job_id": job_id},
+            {"$set": {
+                "status": JobStatus.SUCCEEDED.value,
+                "result": result,
+                "error": None,
+                "finished_at": now,
+                "updated_at": now,
+            }},
+        )
+
+    def fail_or_retry(self, job: Dict[str, Any], error: str) -> None:
+        now = _now()
+        retry_count = int(job.get("retry_count") or 0) + 1
+        max_retries = int(job.get("max_retries") or 0)
+        job_id = job["job_id"]
+
+        if retry_count > max_retries:
+            update = {
+                "$set": {
+                    "status": JobStatus.DEAD_LETTER.value,
+                    "retry_count": retry_count,
+                    "error": error,
+                    "finished_at": now,
+                    "updated_at": now,
+                }
+            }
+            self.jobs.update_one({"job_id": job_id}, update)
+            self.dead_letters.update_one(
+                {"job_id": job_id},
+                {"$set": {"job_id": job_id, "job": _public_job(job), "error": error, "created_at": now}},
+                upsert=True,
+            )
+            return
+
+        delay = min(settings.job_retry_backoff_seconds * (2 ** (retry_count - 1)), 300)
+        self.jobs.update_one(
+            {"job_id": job_id},
+            {"$set": {
+                "status": JobStatus.PENDING.value,
+                "retry_count": retry_count,
+                "error": error,
+                "run_after": now + timedelta(seconds=delay),
+                "updated_at": now,
+            }},
+        )
+
+
+class JobWorker:
+    """Small async poller that executes jobs from the durable queue."""
+
+    def __init__(self, store: JobStore, handlers: Dict[str, JobHandler]) -> None:
+        self.store = store
+        self.handlers = handlers
+        self.worker_id = str(uuid.uuid4())
+        self._task: asyncio.Task | None = None
+        self._stopping = asyncio.Event()
+
+    def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stopping.set()
+        if self._task:
+            await self._task
+
+    async def _run(self) -> None:
+        while not self._stopping.is_set():
+            from src.api.dependencies import is_ready
+
+            if not is_ready():
+                await asyncio.sleep(settings.job_poll_interval_seconds)
+                continue
+
+            job = await asyncio.to_thread(self.store.claim_next, self.worker_id)
+            if not job:
+                await asyncio.sleep(settings.job_poll_interval_seconds)
+                continue
+
+            handler = self.handlers.get(job.get("job_type"))
+            if handler is None:
+                await asyncio.to_thread(
+                    self.store.fail_or_retry,
+                    job,
+                    f"No handler registered for job type {job.get('job_type')!r}",
+                )
+                continue
+
+            try:
+                result = await asyncio.wait_for(
+                    handler(dict(job.get("payload") or {})),
+                    timeout=float(job.get("timeout_seconds") or settings.job_timeout_seconds),
+                )
+                await asyncio.to_thread(self.store.succeed, job["job_id"], result)
+            except Exception as exc:
+                logger.exception("Job %s failed", job.get("job_id"))
+                await asyncio.to_thread(self.store.fail_or_retry, job, str(exc) or repr(exc))
+
+
+_job_store: JobStore | None = None
+_job_worker: JobWorker | None = None
+
+
+def init_jobs(handlers: Dict[str, JobHandler]) -> JobStore | None:
+    global _job_store, _job_worker
+    if not settings.job_worker_enabled:
+        return None
+    try:
+        _job_store = JobStore()
+        _job_worker = JobWorker(_job_store, handlers)
+        _job_worker.start()
+        logger.info("[jobs] Worker started.")
+        return _job_store
+    except Exception as exc:
+        logger.warning("[jobs] Worker disabled; MongoDB job store unavailable: %s", exc)
+        _job_store = None
+        _job_worker = None
+        return None
+
+
+async def shutdown_jobs() -> None:
+    global _job_worker
+    if _job_worker is not None:
+        await _job_worker.stop()
+        _job_worker = None
+
+
+def get_job_store() -> JobStore:
+    if _job_store is None:
+        raise RuntimeError("Job store is not available.")
+    return _job_store
+
+
+def serialize_job(job: Dict[str, Any]) -> Dict[str, Any]:
+    return _public_job(job)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stable(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _stable(value[k]) for k in sorted(value)}
+    if isinstance(value, list):
+        return [_stable(v) for v in value]
+    return value
+
+
+def _public_job(job: Dict[str, Any]) -> Dict[str, Any]:
+    public = {k: v for k, v in job.items() if k != "_id"}
+    public.pop("payload", None)
+    return public

--- a/src/jobs.py
+++ b/src/jobs.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
-import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -50,7 +50,7 @@ class JobStore:
 
     @staticmethod
     def make_idempotency_key(job_type: str, owner_id: str, payload: Dict[str, Any]) -> str:
-        stable = repr(_stable(payload)).encode("utf-8")
+        stable = json.dumps(payload, default=str, separators=(",", ":"), sort_keys=True).encode("utf-8")
         digest = hashlib.sha256(stable).hexdigest()
         return f"{job_type}:{owner_id}:{digest}"
 
@@ -162,9 +162,11 @@ class JobStore:
                 }
             }
             self.jobs.update_one({"job_id": job_id}, update)
+            dead_letter_job = {k: v for k, v in job.items() if k != "_id"}
+            dead_letter_job.update(update["$set"])
             self.dead_letters.update_one(
                 {"job_id": job_id},
-                {"$set": {"job_id": job_id, "job": _public_job(job), "error": error, "created_at": now}},
+                {"$set": {"job_id": job_id, "job": dead_letter_job, "error": error, "created_at": now}},
                 upsert=True,
             )
             return
@@ -274,14 +276,6 @@ def serialize_job(job: Dict[str, Any]) -> Dict[str, Any]:
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
-
-
-def _stable(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {k: _stable(value[k]) for k in sorted(value)}
-    if isinstance(value, list):
-        return [_stable(v) for v in value]
-    return value
 
 
 def _public_job(job: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/jobs.py
+++ b/src/jobs.py
@@ -62,11 +62,18 @@ class JobStore:
         payload: Dict[str, Any],
         idempotency_key: str | None = None,
         timeout_seconds: float | None = None,
+        lease_seconds: float | None = None,
         max_retries: int | None = None,
     ) -> Dict[str, Any]:
         now = _now()
         job_id = str(uuid.uuid4())
         key = idempotency_key or self.make_idempotency_key(job_type, owner_id, payload)
+        effective_timeout = settings.job_timeout_seconds if timeout_seconds is None else timeout_seconds
+        effective_lease = (
+            max(settings.job_lease_seconds, effective_timeout)
+            if lease_seconds is None
+            else lease_seconds
+        )
         doc = {
             "job_id": job_id,
             "job_type": job_type,
@@ -76,7 +83,8 @@ class JobStore:
             "status": JobStatus.PENDING.value,
             "retry_count": 0,
             "max_retries": settings.job_max_retries if max_retries is None else max_retries,
-            "timeout_seconds": settings.job_timeout_seconds if timeout_seconds is None else timeout_seconds,
+            "timeout_seconds": effective_timeout,
+            "lease_seconds": effective_lease,
             "error": None,
             "result": None,
             "run_after": now,
@@ -107,16 +115,6 @@ class JobStore:
 
     def claim_next(self, worker_id: str) -> Optional[Dict[str, Any]]:
         now = _now()
-        stale_before = now - timedelta(seconds=settings.job_lease_seconds)
-        query = {
-            "$or": [
-                {"status": JobStatus.PENDING.value, "run_after": {"$lte": now}},
-                {
-                    "status": JobStatus.RUNNING.value,
-                    "started_at": {"$lt": stale_before},
-                },
-            ]
-        }
         update = {
             "$set": {
                 "status": JobStatus.RUNNING.value,
@@ -125,12 +123,38 @@ class JobStore:
                 "updated_at": now,
             }
         }
-        return self.jobs.find_one_and_update(
-            query,
+        pending = self.jobs.find_one_and_update(
+            {"status": JobStatus.PENDING.value, "run_after": {"$lte": now}},
             update,
             sort=[("run_after", ASCENDING), ("created_at", ASCENDING)],
             return_document=ReturnDocument.AFTER,
         )
+        if pending:
+            return pending
+
+        running = self.jobs.find(
+            {"status": JobStatus.RUNNING.value, "started_at": {"$ne": None}},
+        ).sort([("started_at", ASCENDING)])
+        for job in running:
+            try:
+                lease_seconds = float(job.get("lease_seconds") or settings.job_lease_seconds)
+            except (TypeError, ValueError):
+                lease_seconds = settings.job_lease_seconds
+            stale_before = now - timedelta(seconds=lease_seconds)
+            if job.get("started_at") >= stale_before:
+                continue
+            claimed = self.jobs.find_one_and_update(
+                {
+                    "job_id": job["job_id"],
+                    "status": JobStatus.RUNNING.value,
+                    "started_at": job.get("started_at"),
+                },
+                update,
+                return_document=ReturnDocument.AFTER,
+            )
+            if claimed:
+                return claimed
+        return None
 
     def succeed(self, job_id: str, result: Any) -> None:
         now = _now()

--- a/src/jobs.py
+++ b/src/jobs.py
@@ -12,6 +12,7 @@ from enum import Enum
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 from pymongo import ASCENDING, ReturnDocument
+from pymongo.errors import DuplicateKeyError
 
 from src.config import settings
 
@@ -91,6 +92,7 @@ class JobStore:
             "created_at": now,
             "updated_at": now,
             "started_at": None,
+            "stale_at": None,
             "finished_at": None,
         }
 
@@ -101,7 +103,7 @@ class JobStore:
         try:
             self.jobs.insert_one(doc)
             return doc
-        except Exception:
+        except DuplicateKeyError:
             existing = self.jobs.find_one({"idempotency_key": key})
             if existing:
                 return existing
@@ -115,45 +117,50 @@ class JobStore:
 
     def claim_next(self, worker_id: str) -> Optional[Dict[str, Any]]:
         now = _now()
-        update = {
-            "$set": {
-                "status": JobStatus.RUNNING.value,
-                "worker_id": worker_id,
-                "started_at": now,
-                "updated_at": now,
-            }
-        }
-        pending = self.jobs.find_one_and_update(
-            {"status": JobStatus.PENDING.value, "run_after": {"$lte": now}},
-            update,
-            sort=[("run_after", ASCENDING), ("created_at", ASCENDING)],
-            return_document=ReturnDocument.AFTER,
-        )
-        if pending:
-            return pending
 
-        running = self.jobs.find(
-            {"status": JobStatus.RUNNING.value, "started_at": {"$ne": None}},
-        ).sort([("started_at", ASCENDING)])
-        for job in running:
+        def _claim_update(job: Dict[str, Any]) -> Dict[str, Any]:
             try:
                 lease_seconds = float(job.get("lease_seconds") or settings.job_lease_seconds)
             except (TypeError, ValueError):
                 lease_seconds = settings.job_lease_seconds
-            stale_before = now - timedelta(seconds=lease_seconds)
-            if job.get("started_at") >= stale_before:
-                continue
-            claimed = self.jobs.find_one_and_update(
-                {
-                    "job_id": job["job_id"],
+            return {
+                "$set": {
                     "status": JobStatus.RUNNING.value,
-                    "started_at": job.get("started_at"),
-                },
-                update,
+                    "worker_id": worker_id,
+                    "started_at": now,
+                    "stale_at": now + timedelta(seconds=lease_seconds),
+                    "updated_at": now,
+                }
+            }
+
+        pending_query = {"status": JobStatus.PENDING.value, "run_after": {"$lte": now}}
+        pending_job = self.jobs.find_one(
+            pending_query,
+            sort=[("run_after", ASCENDING), ("created_at", ASCENDING)],
+        )
+        if pending_job:
+            claimed = self.jobs.find_one_and_update(
+                {"job_id": pending_job["job_id"], "status": JobStatus.PENDING.value},
+                _claim_update(pending_job),
                 return_document=ReturnDocument.AFTER,
             )
             if claimed:
                 return claimed
+
+        stale_job = self.jobs.find_one(
+            {"status": JobStatus.RUNNING.value, "stale_at": {"$lte": now}},
+            sort=[("stale_at", ASCENDING), ("started_at", ASCENDING)],
+        )
+        if stale_job:
+            return self.jobs.find_one_and_update(
+                {
+                    "job_id": stale_job["job_id"],
+                    "status": JobStatus.RUNNING.value,
+                    "stale_at": stale_job.get("stale_at"),
+                },
+                _claim_update(stale_job),
+                return_document=ReturnDocument.AFTER,
+            )
         return None
 
     def succeed(self, job_id: str, result: Any) -> None:
@@ -165,6 +172,7 @@ class JobStore:
                 "result": result,
                 "error": None,
                 "finished_at": now,
+                "stale_at": None,
                 "updated_at": now,
             }},
         )
@@ -182,6 +190,7 @@ class JobStore:
                     "retry_count": retry_count,
                     "error": error,
                     "finished_at": now,
+                    "stale_at": None,
                     "updated_at": now,
                 }
             }
@@ -203,6 +212,7 @@ class JobStore:
                 "retry_count": retry_count,
                 "error": error,
                 "run_after": now + timedelta(seconds=delay),
+                "stale_at": None,
                 "updated_at": now,
             }},
         )

--- a/tests/api/test_durable_jobs_routes.py
+++ b/tests/api/test_durable_jobs_routes.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api import dependencies as deps
+from src.api.routes import jobs as jobs_routes
+from src.api.routes import memory as memory_routes
+from src.api.routes.jobs import router as jobs_router
+from src.api.routes.memory import router as memory_router
+from src.api.routes.memory import v2_router as memory_v2_router
+from src.jobs import JobStatus, JobStore
+
+
+class FakeIngestPipeline:
+    model = SimpleNamespace(model="fake-ingest")
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def run(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"classification_result": SimpleNamespace(classifications=[])}
+
+
+class FakeJobStore:
+    def __init__(self) -> None:
+        self.enqueued = []
+
+    def enqueue(self, **kwargs):
+        self.enqueued.append(kwargs)
+        return {
+            "job_id": f"job-{len(self.enqueued)}",
+            "job_type": kwargs["job_type"],
+            "status": "pending",
+            "idempotency_key": kwargs.get("idempotency_key") or "idem-1",
+        }
+
+    def get(self, job_id: str, owner_id: str | None = None):
+        if job_id != "job-1" or owner_id != "Static Key User":
+            return None
+        return {
+            "job_id": job_id,
+            "job_type": "memory.ingest",
+            "status": "pending",
+            "retry_count": 0,
+            "max_retries": 3,
+            "timeout_seconds": 120.0,
+        }
+
+
+def _app(monkeypatch, pipeline: FakeIngestPipeline, store: FakeJobStore) -> FastAPI:
+    monkeypatch.setattr(deps.settings, "api_keys", ["test-static-key"], raising=False)
+    deps._init_error = None
+    deps._pipelines_ready.set()
+    deps._ingest_pipeline = pipeline
+    monkeypatch.setattr(memory_routes, "get_job_store", lambda: store)
+    monkeypatch.setattr(jobs_routes, "get_job_store", lambda: store)
+    app = FastAPI()
+    app.include_router(memory_router)
+    app.include_router(memory_v2_router)
+    app.include_router(jobs_router)
+    return app
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": "Bearer test-static-key"}
+
+
+def _ingest_payload() -> dict[str, str]:
+    return {
+        "user_query": "remember this",
+        "agent_response": "ok",
+        "user_id": "ignored-by-auth",
+    }
+
+
+def test_v1_ingest_remains_synchronous_and_backward_compatible(monkeypatch):
+    pipeline = FakeIngestPipeline()
+    store = FakeJobStore()
+    client = TestClient(_app(monkeypatch, pipeline, store))
+
+    response = client.post("/v1/memory/ingest", json=_ingest_payload(), headers=_auth())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["data"]["model"] == "fake-ingest"
+    assert "job_id" not in body["data"]
+    assert len(pipeline.calls) == 1
+    assert store.enqueued == []
+
+
+def test_v2_ingest_enqueues_durable_job(monkeypatch):
+    pipeline = FakeIngestPipeline()
+    store = FakeJobStore()
+    client = TestClient(_app(monkeypatch, pipeline, store))
+
+    response = client.post("/v2/memory/ingest", json=_ingest_payload(), headers=_auth())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["job_id"] == "job-1"
+    assert body["data"]["job_type"] == "memory.ingest"
+    assert body["data"]["status_url"] == "/v1/jobs/job-1"
+    assert pipeline.calls == []
+    assert store.enqueued[0]["job_type"] == "memory.ingest"
+    assert store.enqueued[0]["owner_id"] == "Static Key User"
+
+
+def test_v2_batch_ingest_enqueues_with_batch_timeout(monkeypatch):
+    pipeline = FakeIngestPipeline()
+    store = FakeJobStore()
+    client = TestClient(_app(monkeypatch, pipeline, store))
+
+    response = client.post(
+        "/v2/memory/batch-ingest",
+        json={"items": [_ingest_payload(), _ingest_payload()]},
+        headers=_auth(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["job_type"] == "memory.batch_ingest"
+    assert store.enqueued[0]["timeout_seconds"] == 240.0
+
+
+def test_job_status_is_scoped_to_authenticated_owner(monkeypatch):
+    pipeline = FakeIngestPipeline()
+    store = FakeJobStore()
+    client = TestClient(_app(monkeypatch, pipeline, store))
+
+    ok = client.get("/v1/jobs/job-1", headers=_auth())
+    missing = client.get("/v1/jobs/other", headers=_auth())
+
+    assert ok.status_code == 200
+    assert ok.json()["data"]["job_id"] == "job-1"
+    assert missing.status_code == 404
+
+
+class FakeCollection:
+    def __init__(self) -> None:
+        self.docs = []
+
+    def create_index(self, *_args, **_kwargs):
+        return None
+
+    def find_one(self, query, projection=None):
+        for doc in self.docs:
+            if _matches(doc, query):
+                return _project(doc, projection)
+        return None
+
+    def insert_one(self, doc):
+        self.docs.append(dict(doc))
+
+    def update_one(self, query, update, upsert=False):
+        doc = self.find_one(query)
+        if doc is None:
+            if not upsert:
+                return None
+            doc = dict(query)
+            self.docs.append(doc)
+        doc.update(update.get("$set", {}))
+        return None
+
+    def find_one_and_update(self, query, update, sort=None, return_document=None):
+        docs = [doc for doc in self.docs if _matches(doc, query)]
+        if sort:
+            for key, direction in reversed(sort):
+                docs.sort(key=lambda item: item.get(key), reverse=direction < 0)
+        if not docs:
+            return None
+        docs[0].update(update.get("$set", {}))
+        return docs[0]
+
+    def find(self, query):
+        return FakeCursor([doc for doc in self.docs if _matches(doc, query)])
+
+
+class FakeCursor(list):
+    def sort(self, sort_spec):
+        for key, direction in reversed(sort_spec):
+            super().sort(key=lambda item: item.get(key), reverse=direction < 0)
+        return self
+
+
+def _matches(doc, query):
+    for key, expected in query.items():
+        actual = doc.get(key)
+        if isinstance(expected, dict):
+            if "$lte" in expected and not (actual <= expected["$lte"]):
+                return False
+            if "$ne" in expected and not (actual != expected["$ne"]):
+                return False
+        elif actual != expected:
+            return False
+    return True
+
+
+def _project(doc, projection):
+    if projection is None:
+        return doc
+    projected = dict(doc)
+    if projection and projection.get("_id") is False:
+        projected.pop("_id", None)
+    return projected
+
+
+def _store(monkeypatch) -> JobStore:
+    jobs = FakeCollection()
+    dead_letters = FakeCollection()
+    store = JobStore.__new__(JobStore)
+    store.jobs = jobs
+    store.dead_letters = dead_letters
+    monkeypatch.setattr("src.jobs.settings.job_timeout_seconds", 120.0, raising=False)
+    monkeypatch.setattr("src.jobs.settings.job_lease_seconds", 300.0, raising=False)
+    monkeypatch.setattr("src.jobs.settings.job_max_retries", 1, raising=False)
+    monkeypatch.setattr("src.jobs.settings.job_retry_backoff_seconds", 5.0, raising=False)
+    return store
+
+
+def test_job_store_idempotency_and_dead_letter_payload(monkeypatch):
+    store = _store(monkeypatch)
+    payload = {"b": 2, "a": 1}
+
+    first = store.enqueue(job_type="memory.ingest", owner_id="user-1", payload=payload)
+    second = store.enqueue(job_type="memory.ingest", owner_id="user-1", payload={"a": 1, "b": 2})
+
+    assert first["job_id"] == second["job_id"]
+    assert first["idempotency_key"] == second["idempotency_key"]
+
+    running = store.claim_next("worker-1")
+    running["retry_count"] = 1
+    running["max_retries"] = 1
+    store.fail_or_retry(running, "boom")
+
+    assert store.dead_letters.docs[0]["job"]["payload"] == payload
+    assert store.dead_letters.docs[0]["job"]["status"] == JobStatus.DEAD_LETTER.value
+
+
+def test_claim_next_respects_per_job_lease(monkeypatch):
+    store = _store(monkeypatch)
+    now = datetime.now(timezone.utc)
+    store.jobs.docs.extend(
+        [
+            {
+                "job_id": "long-running",
+                "status": JobStatus.RUNNING.value,
+                "started_at": now - timedelta(seconds=400),
+                "run_after": now,
+                "created_at": now,
+                "lease_seconds": 600.0,
+            },
+            {
+                "job_id": "stale-running",
+                "status": JobStatus.RUNNING.value,
+                "started_at": now - timedelta(seconds=400),
+                "run_after": now,
+                "created_at": now,
+                "lease_seconds": 300.0,
+            },
+        ]
+    )
+
+    claimed = store.claim_next("worker-1")
+
+    assert claimed["job_id"] == "stale-running"
+    assert store.jobs.docs[0].get("worker_id") != "worker-1"

--- a/tests/api/test_durable_jobs_routes.py
+++ b/tests/api/test_durable_jobs_routes.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.api import dependencies as deps
 from src.api.routes import jobs as jobs_routes
 from src.api.routes import memory as memory_routes
+from src.api.routes import scanner as scanner_routes
 from src.api.routes.jobs import router as jobs_router
 from src.api.routes.memory import router as memory_router
 from src.api.routes.memory import v2_router as memory_v2_router
@@ -147,10 +149,13 @@ class FakeCollection:
     def create_index(self, *_args, **_kwargs):
         return None
 
-    def find_one(self, query, projection=None):
-        for doc in self.docs:
-            if _matches(doc, query):
-                return _project(doc, projection)
+    def find_one(self, query, projection=None, sort=None):
+        docs = [doc for doc in self.docs if _matches(doc, query)]
+        if sort:
+            for key, direction in reversed(sort):
+                docs.sort(key=lambda item: item.get(key), reverse=direction < 0)
+        for doc in docs:
+            return _project(doc, projection)
         return None
 
     def insert_one(self, doc):
@@ -250,6 +255,7 @@ def test_claim_next_respects_per_job_lease(monkeypatch):
                 "job_id": "long-running",
                 "status": JobStatus.RUNNING.value,
                 "started_at": now - timedelta(seconds=400),
+                "stale_at": now + timedelta(seconds=200),
                 "run_after": now,
                 "created_at": now,
                 "lease_seconds": 600.0,
@@ -258,6 +264,7 @@ def test_claim_next_respects_per_job_lease(monkeypatch):
                 "job_id": "stale-running",
                 "status": JobStatus.RUNNING.value,
                 "started_at": now - timedelta(seconds=400),
+                "stale_at": now - timedelta(seconds=100),
                 "run_after": now,
                 "created_at": now,
                 "lease_seconds": 300.0,
@@ -269,3 +276,45 @@ def test_claim_next_respects_per_job_lease(monkeypatch):
 
     assert claimed["job_id"] == "stale-running"
     assert store.jobs.docs[0].get("worker_id") != "worker-1"
+
+
+@pytest.mark.asyncio
+async def test_scanner_enqueue_does_not_persist_github_pat(monkeypatch):
+    store = FakeJobStore()
+    scanner_routes._scanner_pat_refs.clear()
+    monkeypatch.setattr(scanner_routes, "get_job_store", lambda: store)
+
+    queue_job_id = await scanner_routes._enqueue_or_start_scanner_job(
+        job_type="scanner.scan",
+        scanner_job_id="user:org:repo",
+        username="user",
+        org="org",
+        repo="repo",
+        url="https://github.com/org/repo.git",
+        branch="main",
+        pat="ghp_secret",
+    )
+
+    assert queue_job_id == "job-1"
+    payload = store.enqueued[0]["payload"]
+    assert "pat" not in payload
+    assert payload["requires_pat"] is True
+    assert scanner_routes._resolve_scanner_pat(payload) == "ghp_secret"
+
+
+@pytest.mark.asyncio
+async def test_scanner_job_fails_closed_when_pat_ref_is_missing():
+    scanner_routes._scanner_pat_refs.clear()
+
+    with pytest.raises(RuntimeError, match="credential is no longer available"):
+        await scanner_routes.run_scanner_job(
+            {
+                "scanner_job_id": "user:org:repo",
+                "username": "user",
+                "org": "org",
+                "repo": "repo",
+                "url": "https://github.com/org/repo.git",
+                "branch": "main",
+                "requires_pat": True,
+            }
+        )


### PR DESCRIPTION
Refs #162

## Summary
- add a MongoDB-backed durable job queue with idempotency keys, retries, timeouts, stale lease recovery, and dead-letter records
- enqueue `/v1/memory/ingest` and `/v1/memory/batch-ingest` work and expose `/v1/jobs/{job_id}` for job status/results
- route scanner start/resume work through the durable queue while preserving the existing scanner job/status records and falling back to in-process tasks if the job store is unavailable
- add job worker settings for polling, timeout, retry, backoff, and lease duration

This is a focused Phase 1 implementation for the task-queue/status foundation described in the issue discussion.

## Validation
- `python3 -m py_compile src/jobs.py src/api/routes/jobs.py src/api/routes/memory.py src/api/routes/scanner.py src/api/app.py src/api/schemas.py`
- `git diff --check`
- `uv run --with pytest --with pytest-asyncio --with fastapi --with pydantic --with pydantic-settings --with python-jose --with pymongo --with httpx --with beautifulsoup4 pytest tests/api/test_dependencies_and_routes.py -q` -> 4 passed
