### PR TITLE
Add memory hashing, versioning, and forget support

### DIFF
--- a/src/agents/judge.py
+++ b/src/agents/judge.py
@@ -87,6 +87,15 @@ def _format_similar_block(
     return "\n".join(lines)
 
 
+def _active_memory_results(results: List[SearchResult], limit: int) -> List[SearchResult]:
+    active = [
+        result for result in results
+        if result.metadata.get("is_current") is not False
+        and not result.metadata.get("forgotten_at")
+    ]
+    return active[:limit]
+
+
 # ---------------------------------------------------------------------------
 # Type alias for the Neo4j event search callable that the pipeline injects.
 #
@@ -264,7 +273,7 @@ class JudgeAgent(BaseAgent):
                     query_text=item_str,
                     filters=filters if filters else None,
                 )
-                return item_str, results
+                return item_str, _active_memory_results(results, self.top_k)
             except Exception as exc:
                 self.logger.warning(
                     "Vector search failed for '%s': %s", item_str[:60], exc
@@ -306,9 +315,9 @@ class JudgeAgent(BaseAgent):
                 if search_fn is not None:
                     # search_by_metadata is sync — run in thread pool
                     results = await asyncio.to_thread(
-                        search_fn, filters=filters, top_k=self.top_k,
+                        search_fn, filters=filters, top_k=max(self.top_k * 5, 10),
                     )
-                    return item_str, results if results else []
+                    return item_str, _active_memory_results(results or [], self.top_k)
                 else:
                     self.logger.debug(
                         "Vector store has no search_by_metadata — "
@@ -318,7 +327,7 @@ class JudgeAgent(BaseAgent):
                         query_text=item_str,
                         filters={"user_id": user_id, "domain": "profile"} if user_id else None,
                     )
-                    return item_str, results
+                    return item_str, _active_memory_results(results, self.top_k)
             except Exception as exc:
                 self.logger.warning(
                     "Profile metadata search failed for '%s': %s",
@@ -344,7 +353,11 @@ class JudgeAgent(BaseAgent):
 
         search_fn = getattr(self.vector_store, "search_by_text", None)
         if search_fn is not None:
-            return await search_fn(query_text, top_k=self.top_k, filters=filters)
+            return await search_fn(
+                query_text,
+                top_k=max(self.top_k * 5, 10),
+                filters=filters,
+            )
 
         self.logger.debug(
             "Vector store has no search_by_text — skipping search for this item."

--- a/src/agents/judge.py
+++ b/src/agents/judge.py
@@ -91,7 +91,6 @@ def _active_memory_results(results: List[SearchResult], limit: int) -> List[Sear
     active = [
         result for result in results
         if result.metadata.get("is_current") is not False
-        and not result.metadata.get("forgotten_at")
     ]
     return active[:limit]
 

--- a/src/pipelines/retrieval.py
+++ b/src/pipelines/retrieval.py
@@ -42,6 +42,10 @@ load_dotenv()
 logger = logging.getLogger("xmem.pipelines.retrieval")
 
 
+def _is_active_memory(metadata: Dict[str, Any]) -> bool:
+    return metadata.get("is_current") is not False and not metadata.get("forgotten_at")
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Tool schemas — These are the "function signatures" exposed to the LLM
 # ═══════════════════════════════════════════════════════════════════════════
@@ -417,7 +421,7 @@ class RetrievalPipeline:
 
         results = await self.vector_store.search_by_text(
             query_text=query,
-            top_k=top_k,
+            top_k=max(top_k * 2, 10),
             filters={
                 "user_id": user_id,
                 "domain": "summary",
@@ -426,12 +430,16 @@ class RetrievalPipeline:
 
         records = []
         for r in results:
+            if not _is_active_memory(r.metadata):
+                continue
             records.append(SourceRecord(
                 domain="summary",
                 content=r.content,
                 score=r.score,
                 metadata={"id": r.id, **r.metadata},
             ))
+            if len(records) >= top_k:
+                break
 
         logger.info("  → Summary [%s]: %d results", query, len(records))
         return records
@@ -507,6 +515,8 @@ class RetrievalPipeline:
         seen = set()
 
         for r in results:
+            if not _is_active_memory(r.metadata):
+                continue
             main_content = r.metadata.get("main_content", "")
             if not main_content or main_content in seen:
                 continue

--- a/src/pipelines/retrieval.py
+++ b/src/pipelines/retrieval.py
@@ -43,7 +43,7 @@ logger = logging.getLogger("xmem.pipelines.retrieval")
 
 
 def _is_active_memory(metadata: Dict[str, Any]) -> bool:
-    return metadata.get("is_current") is not False and not metadata.get("forgotten_at")
+    return metadata.get("is_current") is not False
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/src/pipelines/weaver.py
+++ b/src/pipelines/weaver.py
@@ -16,6 +16,7 @@ import asyncio
 from functools import partial
 import hashlib
 import logging
+import uuid
 from typing import Any, Callable, Dict, List, Optional
 
 from src.schemas.judge import (
@@ -28,6 +29,7 @@ from src.schemas.weaver import ExecutedOp, OpStatus, WeaverResult
 from src.storage.base import BaseVectorStore
 
 logger = logging.getLogger("xmem.weaver")
+LINEAGE_SEARCH_TOP_K = 10_000
 
 
 def _content_hash(content: str) -> str:
@@ -35,7 +37,7 @@ def _content_hash(content: str) -> str:
 
 
 def _is_inactive_memory(metadata: Dict[str, Any]) -> bool:
-    return metadata.get("is_current") is False or bool(metadata.get("forgotten_at"))
+    return metadata.get("is_current") is False
 
 
 def _memory_metadata(
@@ -159,6 +161,7 @@ class Weaver:
             # Prepare data for batch add
             valid_ops = []
             texts = []
+            ids = []
             metadatas = []
 
             for op in add_batch_ops:
@@ -187,10 +190,17 @@ class Weaver:
                         ))
                         continue
 
-                    meta = _memory_metadata(op.content, domain, user_id)
+                    new_id = self._new_memory_id()
+                    meta = _memory_metadata(
+                        op.content,
+                        domain,
+                        user_id,
+                        parent_memory_id=new_id,
+                    )
 
                     valid_ops.append(op)
                     texts.append(op.content)
+                    ids.append(new_id)
                     metadatas.append(meta)
                 except Exception as exc:
                     logger.error("Metadata extraction failed for ADD: %s", exc)
@@ -210,10 +220,13 @@ class Weaver:
 
                 successful_ops = []
                 successful_texts = []
+                successful_ids = []
                 successful_embeddings = []
                 successful_metadatas = []
 
-                for op, text, meta, res in zip(valid_ops, texts, metadatas, results):
+                for op, text, new_id, meta, res in zip(
+                    valid_ops, texts, ids, metadatas, results
+                ):
                     if isinstance(res, Exception):
                         logger.error("Embedding generation failed for ADD: %s", res)
                         executed_ops.append(ExecutedOp(
@@ -223,6 +236,7 @@ class Weaver:
                     else:
                         successful_ops.append(op)
                         successful_texts.append(text)
+                        successful_ids.append(new_id)
                         successful_embeddings.append(res)
                         successful_metadatas.append(meta)
 
@@ -234,12 +248,12 @@ class Weaver:
                                 self.vector_store.add,
                                 texts=successful_texts,
                                 embeddings=successful_embeddings,
+                                ids=successful_ids,
                                 metadata=successful_metadatas,
                             )
                         )
                         # Map IDs back to ops
-                        for op, new_id in zip(successful_ops, ids):
-                            self._set_parent_memory_id(new_id)
+                        for op, new_id in zip(successful_ops, successful_ids):
                             executed_ops.append(ExecutedOp(
                                 type=op.type, status=OpStatus.SUCCESS,
                                 content=op.content, new_id=new_id,
@@ -420,16 +434,21 @@ class Weaver:
             )
 
         embedding = self.embed_fn(op.content)
-        metadata = _memory_metadata(op.content, domain, user_id)
+        new_id = self._new_memory_id()
+        metadata = _memory_metadata(
+            op.content,
+            domain,
+            user_id,
+            parent_memory_id=new_id,
+        )
 
         ids = self.vector_store.add(
             texts=[op.content],
             embeddings=[embedding],
+            ids=[new_id],
             metadata=[metadata],
         )
         new_id = ids[0] if ids else None
-        if new_id:
-            self._set_parent_memory_id(new_id)
         return ExecutedOp(
             type=op.type, status=OpStatus.SUCCESS,
             content=op.content, new_id=new_id,
@@ -452,6 +471,15 @@ class Weaver:
             return await self._vector_add(op, domain, user_id)
 
         previous_meta = dict(previous.get("metadata") or {})
+        parent_memory_id = str(
+            previous_meta.get("parent_memory_id") or op.embedding_id
+        )
+        lineage = self._lineage_matches(parent_memory_id)
+        current = self._current_lineage_doc(lineage)
+        if current:
+            previous = current
+            previous_meta = dict(previous.get("metadata") or {})
+
         new_hash = _content_hash(op.content)
         if previous_meta.get("content_hash") == new_hash and not _is_inactive_memory(previous_meta):
             return ExecutedOp(
@@ -463,10 +491,8 @@ class Weaver:
             )
 
         embedding = self.embed_fn(op.content)
-        parent_memory_id = str(
-            previous_meta.get("parent_memory_id") or op.embedding_id
-        )
-        version = int(previous_meta.get("version") or 1) + 1
+        version = self._next_lineage_version(parent_memory_id, lineage)
+        new_id = self._new_memory_id()
         metadata = _memory_metadata(
             op.content,
             domain,
@@ -478,6 +504,7 @@ class Weaver:
         ids = self.vector_store.add(
             texts=[op.content],
             embeddings=[embedding],
+            ids=[new_id],
             metadata=[metadata],
         )
         new_id = ids[0] if ids else None
@@ -490,13 +517,17 @@ class Weaver:
                 error="Vector store did not return a new version id",
             )
 
-        self._mark_memory_superseded(op.embedding_id, previous, new_id)
+        self._mark_lineage_superseded(
+            matches=lineage,
+            previous=previous,
+            superseded_by=new_id,
+        )
 
         return ExecutedOp(
             type=op.type,
             status=OpStatus.SUCCESS,
             content=op.content,
-            embedding_id=op.embedding_id,
+            embedding_id=previous.get("id") or op.embedding_id,
             new_id=new_id,
         )
 
@@ -542,34 +573,72 @@ class Weaver:
         docs = self.vector_store.get(ids=[embedding_id])
         return docs[0] if docs else None
 
-    def _set_parent_memory_id(self, memory_id: Optional[str]) -> None:
-        if not memory_id:
-            return
-        try:
-            self.vector_store.update(
-                id=memory_id,
-                metadata={"parent_memory_id": memory_id},
-            )
-        except Exception as exc:
-            logger.warning("Could not set parent_memory_id for %s: %s", memory_id, exc)
+    def _new_memory_id(self) -> str:
+        return str(uuid.uuid4())
 
-    def _mark_memory_superseded(
+    def _lineage_matches(self, parent_memory_id: str) -> List[Any]:
+        search_fn = getattr(self.vector_store, "search_by_metadata", None)
+        if not search_fn:
+            return []
+        try:
+            return search_fn(
+                filters={"parent_memory_id": parent_memory_id},
+                top_k=LINEAGE_SEARCH_TOP_K,
+            ) or []
+        except Exception as exc:
+            logger.warning("Lineage lookup failed for %s: %s", parent_memory_id, exc)
+            return []
+
+    def _current_lineage_doc(self, matches: List[Any]) -> Optional[Dict[str, Any]]:
+        active_matches = [
+            match for match in matches
+            if not _is_inactive_memory(match.metadata)
+        ]
+        if not active_matches:
+            return None
+        current = max(
+            active_matches,
+            key=lambda match: int((match.metadata or {}).get("version") or 1),
+        )
+        return self._get_vector_doc(current.id)
+
+    def _next_lineage_version(self, parent_memory_id: str, matches: List[Any]) -> int:
+        versions = [
+            int((match.metadata or {}).get("version") or 1)
+            for match in matches
+        ]
+        if not versions:
+            parent = self._get_vector_doc(parent_memory_id)
+            if parent:
+                metadata = dict(parent.get("metadata") or {})
+                versions.append(int(metadata.get("version") or 1))
+        return max(versions or [0]) + 1
+
+    def _mark_lineage_superseded(
         self,
-        memory_id: Optional[str],
+        matches: List[Any],
         previous: Dict[str, Any],
         superseded_by: str,
     ) -> None:
-        if not memory_id:
-            return
-        self.vector_store.update(
-            id=memory_id,
-            text=previous.get("content"),
-            embedding=previous.get("embedding"),
-            metadata={
-                "is_current": False,
-                "superseded_by": superseded_by,
-            },
-        )
+        ids_to_mark = {
+            match.id for match in matches
+            if match.id != superseded_by and not _is_inactive_memory(match.metadata)
+        }
+        if (
+            previous.get("id")
+            and previous["id"] != superseded_by
+            and not _is_inactive_memory(dict(previous.get("metadata") or {}))
+        ):
+            ids_to_mark.add(previous["id"])
+
+        for memory_id in ids_to_mark:
+            self.vector_store.update(
+                id=memory_id,
+                metadata={
+                    "is_current": False,
+                    "superseded_by": superseded_by,
+                },
+            )
 
     def _lineage_ids_for_forget(self, memory_id: Optional[str]) -> List[str]:
         if not memory_id:
@@ -581,13 +650,8 @@ class Weaver:
         metadata = dict(target.get("metadata") or {})
         parent_memory_id = str(metadata.get("parent_memory_id") or memory_id)
         ids = {memory_id, parent_memory_id}
-        search_fn = getattr(self.vector_store, "search_by_metadata", None)
-        if search_fn:
-            for match in search_fn(
-                filters={"parent_memory_id": parent_memory_id},
-                top_k=100,
-            ) or []:
-                ids.add(match.id)
+        for match in self._lineage_matches(parent_memory_id):
+            ids.add(match.id)
 
         return list(ids)
 

--- a/src/pipelines/weaver.py
+++ b/src/pipelines/weaver.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
+import hashlib
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -27,6 +28,36 @@ from src.schemas.weaver import ExecutedOp, OpStatus, WeaverResult
 from src.storage.base import BaseVectorStore
 
 logger = logging.getLogger("xmem.weaver")
+
+
+def _content_hash(content: str) -> str:
+    return hashlib.sha256((content or "").encode("utf-8")).hexdigest()
+
+
+def _is_inactive_memory(metadata: Dict[str, Any]) -> bool:
+    return metadata.get("is_current") is False or bool(metadata.get("forgotten_at"))
+
+
+def _memory_metadata(
+    content: str,
+    domain: JudgeDomain,
+    user_id: str,
+    *,
+    version: int = 1,
+    parent_memory_id: Optional[str] = None,
+    is_current: bool = True,
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {
+        "user_id": user_id,
+        "domain": domain.value,
+        "content_hash": _content_hash(content),
+        "version": version,
+        "is_current": is_current,
+    }
+    if parent_memory_id:
+        metadata["parent_memory_id"] = parent_memory_id
+    metadata.update(_extract_structured_metadata(content))
+    return metadata
 
 
 # ---------------------------------------------------------------------------
@@ -140,8 +171,23 @@ class Weaver:
                     continue
 
                 try:
-                    meta = {"user_id": user_id, "domain": domain.value}
-                    meta.update(_extract_structured_metadata(op.content))
+                    duplicate = self._find_active_duplicate(op, domain, user_id)
+                    if duplicate:
+                        logger.info(
+                            "Skipping duplicate %s memory with content_hash=%s",
+                            domain.value,
+                            duplicate.metadata.get("content_hash"),
+                        )
+                        executed_ops.append(ExecutedOp(
+                            type=op.type,
+                            status=OpStatus.SKIPPED,
+                            content=op.content,
+                            embedding_id=duplicate.id,
+                            error="Duplicate content hash",
+                        ))
+                        continue
+
+                    meta = _memory_metadata(op.content, domain, user_id)
 
                     valid_ops.append(op)
                     texts.append(op.content)
@@ -193,6 +239,7 @@ class Weaver:
                         )
                         # Map IDs back to ops
                         for op, new_id in zip(successful_ops, ids):
+                            self._set_parent_memory_id(new_id)
                             executed_ops.append(ExecutedOp(
                                 type=op.type, status=OpStatus.SUCCESS,
                                 content=op.content, new_id=new_id,
@@ -212,8 +259,6 @@ class Weaver:
                 return
 
             valid_ops = []
-            ids_to_delete = []
-
             for op in delete_batch_ops:
                 if not op.embedding_id:
                      logger.warning("DELETE missing embedding_id — skipping.")
@@ -224,25 +269,10 @@ class Weaver:
                      continue
 
                 valid_ops.append(op)
-                ids_to_delete.append(op.embedding_id)
 
             if valid_ops:
-                loop = asyncio.get_running_loop()
-                try:
-                    success = await loop.run_in_executor(None, partial(self.vector_store.delete, ids=ids_to_delete))
-                    status = OpStatus.SUCCESS if success else OpStatus.FAILED
-                    for op in valid_ops:
-                        executed_ops.append(ExecutedOp(
-                            type=op.type, status=status,
-                            embedding_id=op.embedding_id
-                        ))
-                except Exception as exc:
-                    logger.error("Vector batch DELETE failed: %s", exc)
-                    for op in valid_ops:
-                        executed_ops.append(ExecutedOp(
-                            type=op.type, status=OpStatus.FAILED,
-                            embedding_id=op.embedding_id, error=str(exc)
-                        ))
+                for op in valid_ops:
+                    executed_ops.append(await self._vector_delete(op))
 
             delete_batch_ops.clear()
 
@@ -379,12 +409,18 @@ class Weaver:
                 content=op.content, error="No embed_fn provided",
             )
 
-        embedding = self.embed_fn(op.content)
-        metadata = {"user_id": user_id, "domain": domain.value}
+        duplicate = self._find_active_duplicate(op, domain, user_id)
+        if duplicate:
+            return ExecutedOp(
+                type=op.type,
+                status=OpStatus.SKIPPED,
+                content=op.content,
+                embedding_id=duplicate.id,
+                error="Duplicate content hash",
+            )
 
-        # Store structured metadata for deterministic lookups
-        structured = _extract_structured_metadata(op.content)
-        metadata.update(structured)
+        embedding = self.embed_fn(op.content)
+        metadata = _memory_metadata(op.content, domain, user_id)
 
         ids = self.vector_store.add(
             texts=[op.content],
@@ -392,6 +428,8 @@ class Weaver:
             metadata=[metadata],
         )
         new_id = ids[0] if ids else None
+        if new_id:
+            self._set_parent_memory_id(new_id)
         return ExecutedOp(
             type=op.type, status=OpStatus.SUCCESS,
             content=op.content, new_id=new_id,
@@ -406,37 +444,152 @@ class Weaver:
                 content=op.content, error="No embed_fn provided",
             )
 
-        embedding = self.embed_fn(op.content)
-        metadata = {"user_id": user_id, "domain": domain.value}
-
-        # Store structured metadata for deterministic lookups
-        structured = _extract_structured_metadata(op.content)
-        metadata.update(structured)
-
-        success = self.vector_store.update(
-            id=op.embedding_id,
-            text=op.content,
-            embedding=embedding,
-            metadata=metadata,
-        )
-        if success:
-            return ExecutedOp(
-                type=op.type, status=OpStatus.SUCCESS,
-                content=op.content, embedding_id=op.embedding_id,
-            )
-        else:
+        previous = self._get_vector_doc(op.embedding_id)
+        if not previous:
             logger.warning(
                 "UPDATE target %s not found — falling back to ADD.", op.embedding_id,
             )
             return await self._vector_add(op, domain, user_id)
 
+        previous_meta = dict(previous.get("metadata") or {})
+        new_hash = _content_hash(op.content)
+        if previous_meta.get("content_hash") == new_hash and not _is_inactive_memory(previous_meta):
+            return ExecutedOp(
+                type=op.type,
+                status=OpStatus.SKIPPED,
+                content=op.content,
+                embedding_id=op.embedding_id,
+                error="Duplicate content hash",
+            )
+
+        embedding = self.embed_fn(op.content)
+        parent_memory_id = str(
+            previous_meta.get("parent_memory_id") or op.embedding_id
+        )
+        version = int(previous_meta.get("version") or 1) + 1
+        metadata = _memory_metadata(
+            op.content,
+            domain,
+            user_id,
+            version=version,
+            parent_memory_id=parent_memory_id,
+        )
+
+        ids = self.vector_store.add(
+            texts=[op.content],
+            embeddings=[embedding],
+            metadata=[metadata],
+        )
+        new_id = ids[0] if ids else None
+        if not new_id:
+            return ExecutedOp(
+                type=op.type,
+                status=OpStatus.FAILED,
+                content=op.content,
+                embedding_id=op.embedding_id,
+                error="Vector store did not return a new version id",
+            )
+
+        self._mark_memory_superseded(op.embedding_id, previous, new_id)
+
+        return ExecutedOp(
+            type=op.type,
+            status=OpStatus.SUCCESS,
+            content=op.content,
+            embedding_id=op.embedding_id,
+            new_id=new_id,
+        )
+
     async def _vector_delete(self, op: Operation) -> ExecutedOp:
-        success = self.vector_store.delete(ids=[op.embedding_id])
+        ids = self._lineage_ids_for_forget(op.embedding_id)
+        success = self.vector_store.delete(ids=ids)
         return ExecutedOp(
             type=op.type,
             status=OpStatus.SUCCESS if success else OpStatus.FAILED,
             embedding_id=op.embedding_id,
         )
+
+    def _find_active_duplicate(
+        self,
+        op: Operation,
+        domain: JudgeDomain,
+        user_id: str,
+    ) -> Optional[Any]:
+        search_fn = getattr(self.vector_store, "search_by_metadata", None)
+        if not search_fn or not op.content:
+            return None
+
+        try:
+            matches = search_fn(
+                filters={
+                    "user_id": user_id,
+                    "domain": domain.value,
+                    "content_hash": _content_hash(op.content),
+                },
+                top_k=10,
+            )
+        except Exception as exc:
+            logger.warning("Duplicate lookup failed; proceeding with ADD: %s", exc)
+            return None
+        for match in matches or []:
+            if not _is_inactive_memory(match.metadata):
+                return match
+        return None
+
+    def _get_vector_doc(self, embedding_id: Optional[str]) -> Optional[Dict[str, Any]]:
+        if not embedding_id:
+            return None
+        docs = self.vector_store.get(ids=[embedding_id])
+        return docs[0] if docs else None
+
+    def _set_parent_memory_id(self, memory_id: Optional[str]) -> None:
+        if not memory_id:
+            return
+        try:
+            self.vector_store.update(
+                id=memory_id,
+                metadata={"parent_memory_id": memory_id},
+            )
+        except Exception as exc:
+            logger.warning("Could not set parent_memory_id for %s: %s", memory_id, exc)
+
+    def _mark_memory_superseded(
+        self,
+        memory_id: Optional[str],
+        previous: Dict[str, Any],
+        superseded_by: str,
+    ) -> None:
+        if not memory_id:
+            return
+        self.vector_store.update(
+            id=memory_id,
+            text=previous.get("content"),
+            embedding=previous.get("embedding"),
+            metadata={
+                "is_current": False,
+                "superseded_by": superseded_by,
+            },
+        )
+
+    def _lineage_ids_for_forget(self, memory_id: Optional[str]) -> List[str]:
+        if not memory_id:
+            return []
+        target = self._get_vector_doc(memory_id)
+        if not target:
+            return [memory_id]
+
+        metadata = dict(target.get("metadata") or {})
+        parent_memory_id = str(metadata.get("parent_memory_id") or memory_id)
+        ids = {memory_id, parent_memory_id}
+        search_fn = getattr(self.vector_store, "search_by_metadata", None)
+        if search_fn:
+            for match in search_fn(
+                filters={"parent_memory_id": parent_memory_id},
+                top_k=100,
+            ) or []:
+                ids.add(match.id)
+
+        return list(ids)
 
     # ------------------------------------------------------------------
     # Temporal → Neo4j

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,7 @@ class InMemoryVectorStore:
         if embedding is not None:
             current["embedding"] = embedding
         if metadata is not None:
-            current["metadata"] = metadata
+            current["metadata"] = {**current["metadata"], **metadata}
         return True
 
     def delete(self, ids):

--- a/tests/integration/test_weaver_pipeline.py
+++ b/tests/integration/test_weaver_pipeline.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
+
 import pytest
 
-from src.pipelines.weaver import Weaver
 from src.schemas.judge import JudgeDomain, JudgeResult, Operation, OperationType
 from src.schemas.weaver import OpStatus
+
+WEAVER_PATH = Path(__file__).resolve().parents[2] / "src" / "pipelines" / "weaver.py"
+weaver_spec = importlib.util.spec_from_file_location("weaver_under_test", WEAVER_PATH)
+weaver_module = importlib.util.module_from_spec(weaver_spec)
+weaver_spec.loader.exec_module(weaver_module)
+Weaver = weaver_module.Weaver
 
 
 @pytest.mark.asyncio
@@ -30,8 +38,14 @@ async def test_weaver_batches_vector_add_update_and_delete(vector_store, fast_em
 
     assert result.succeeded == 3
     assert vector_store.add_calls[0]["texts"] == ["work / title = Engineer"]
-    assert vector_store.records["profile-1"]["content"] == "work / company = XMem"
-    assert vector_store.records["profile-1"]["metadata"]["main_content"] == "work_company"
+    update_result = result.executed[1]
+    assert update_result.new_id
+    assert vector_store.records["profile-1"]["content"] == "work / company = OldCo"
+    assert vector_store.records["profile-1"]["metadata"]["is_current"] is False
+    assert vector_store.records["profile-1"]["metadata"]["superseded_by"] == update_result.new_id
+    assert vector_store.records[update_result.new_id]["content"] == "work / company = XMem"
+    assert vector_store.records[update_result.new_id]["metadata"]["main_content"] == "work_company"
+    assert vector_store.records[update_result.new_id]["metadata"]["version"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_deterministic_memory_layer.py
+++ b/tests/test_deterministic_memory_layer.py
@@ -67,19 +67,20 @@ class FakeVectorStore:
                 ))
         return matches[:top_k]
 
-    def add(self, texts, embeddings, metadata):
+    def add(self, texts, embeddings, ids=None, metadata=None):
         self.add_calls.append((texts, embeddings, metadata))
-        ids = []
-        for text, embedding, meta in zip(texts, embeddings, metadata):
-            record_id = f"vec-{self.next_id}"
-            self.next_id += 1
+        created_ids = []
+        for idx, (text, embedding, meta) in enumerate(zip(texts, embeddings, metadata)):
+            record_id = ids[idx] if ids else f"vec-{self.next_id}"
+            if not ids:
+                self.next_id += 1
             self.records[record_id] = {
                 "text": text,
                 "metadata": meta,
                 "embedding": embedding,
             }
-            ids.append(record_id)
-        return ids
+            created_ids.append(record_id)
+        return created_ids
 
     def update(self, id, text=None, embedding=None, metadata=None):
         self.update_calls.append((id, text, embedding, metadata))
@@ -287,6 +288,7 @@ async def test_weaver_skips_duplicate_memory_by_content_hash():
     assert second.executed[0].status == OpStatus.SKIPPED
     assert second.executed[0].embedding_id == first.executed[0].new_id
     assert len(store.add_calls) == 1
+    assert not store.update_calls
 
 
 @pytest.mark.asyncio
@@ -323,6 +325,53 @@ async def test_forget_deletes_all_versions_in_lineage():
 
     assert deleted.executed[0].status == OpStatus.SUCCESS
     assert store.records == {}
+
+
+@pytest.mark.asyncio
+async def test_stale_update_supersedes_current_lineage_version():
+    store = FakeVectorStore()
+    weaver = Weaver(vector_store=store, embed_fn=fake_embed)
+
+    first = await weaver.execute(
+        JudgeResult(operations=[
+            Operation(type=OperationType.ADD, content="work / company = Google"),
+        ]),
+        JudgeDomain.PROFILE,
+        "user-1",
+    )
+    first_id = first.executed[0].new_id
+    second = await weaver.execute(
+        JudgeResult(operations=[
+            Operation(
+                type=OperationType.UPDATE,
+                embedding_id=first_id,
+                content="work / company = OpenAI",
+            ),
+        ]),
+        JudgeDomain.PROFILE,
+        "user-1",
+    )
+
+    stale = await weaver.execute(
+        JudgeResult(operations=[
+            Operation(
+                type=OperationType.UPDATE,
+                embedding_id=first_id,
+                content="work / company = Anthropic",
+            ),
+        ]),
+        JudgeDomain.PROFILE,
+        "user-1",
+    )
+
+    second_id = second.executed[0].new_id
+    third_id = stale.executed[0].new_id
+
+    assert stale.executed[0].embedding_id == second_id
+    assert store.records[first_id]["metadata"]["is_current"] is False
+    assert store.records[second_id]["metadata"]["is_current"] is False
+    assert store.records[third_id]["metadata"]["is_current"] is True
+    assert store.records[third_id]["metadata"]["version"] == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_deterministic_memory_layer.py
+++ b/tests/test_deterministic_memory_layer.py
@@ -23,7 +23,7 @@ sys.modules.setdefault("langchain_core.language_models", language_models)
 sys.modules.setdefault("langchain_core.messages", messages)
 
 from src.agents.judge import JudgeAgent
-from src.schemas.judge import JudgeDomain, OperationType
+from src.schemas.judge import JudgeDomain, JudgeResult, Operation, OperationType
 from src.schemas.weaver import OpStatus
 from src.storage.base import SearchResult
 
@@ -81,14 +81,17 @@ class FakeVectorStore:
             ids.append(record_id)
         return ids
 
-    def update(self, id, text, embedding, metadata):
+    def update(self, id, text=None, embedding=None, metadata=None):
         self.update_calls.append((id, text, embedding, metadata))
         if id not in self.records:
             return False
+        current = self.records[id]
+        merged_metadata = dict(current["metadata"])
+        merged_metadata.update(metadata or {})
         self.records[id] = {
-            "text": text,
-            "metadata": metadata,
-            "embedding": embedding,
+            "text": text if text is not None else current["text"],
+            "metadata": merged_metadata,
+            "embedding": embedding if embedding is not None else current["embedding"],
         }
         return True
 
@@ -97,6 +100,18 @@ class FakeVectorStore:
         for record_id in ids:
             self.records.pop(record_id, None)
         return True
+
+    def get(self, ids):
+        return [
+            {
+                "id": record_id,
+                "content": self.records[record_id]["text"],
+                "metadata": self.records[record_id]["metadata"],
+                "embedding": self.records[record_id]["embedding"],
+            }
+            for record_id in ids
+            if record_id in self.records
+        ]
 
 
 class FakeTemporalGraph:
@@ -236,9 +251,78 @@ async def test_profile_memory_layer_updates_changed_profile_fact():
 
     assert weaver_result.total == 1
     assert weaver_result.executed[0].status == OpStatus.SUCCESS
-    assert store.records["profile-1"]["text"] == "work / company = OpenAI"
-    assert store.records["profile-1"]["metadata"]["main_content"] == "work_company"
-    assert store.records["profile-1"]["metadata"]["subcontent"] == "OpenAI"
+    new_id = weaver_result.executed[0].new_id
+    assert new_id
+    assert store.records["profile-1"]["text"] == "work / company = Google"
+    assert store.records["profile-1"]["metadata"]["is_current"] is False
+    assert store.records["profile-1"]["metadata"]["superseded_by"] == new_id
+    assert store.records[new_id]["text"] == "work / company = OpenAI"
+    assert store.records[new_id]["metadata"]["main_content"] == "work_company"
+    assert store.records[new_id]["metadata"]["subcontent"] == "OpenAI"
+    assert store.records[new_id]["metadata"]["parent_memory_id"] == "profile-1"
+    assert store.records[new_id]["metadata"]["version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_weaver_skips_duplicate_memory_by_content_hash():
+    store = FakeVectorStore()
+    weaver = Weaver(vector_store=store, embed_fn=fake_embed)
+
+    first = await weaver.execute(
+        JudgeResult(operations=[
+            Operation(type=OperationType.ADD, content="work / title = Engineer"),
+        ]),
+        JudgeDomain.PROFILE,
+        "user-1",
+    )
+    second = await weaver.execute(
+        JudgeResult(operations=[
+            Operation(type=OperationType.ADD, content="work / title = Engineer"),
+        ]),
+        JudgeDomain.PROFILE,
+        "user-1",
+    )
+
+    assert first.executed[0].status == OpStatus.SUCCESS
+    assert second.executed[0].status == OpStatus.SKIPPED
+    assert second.executed[0].embedding_id == first.executed[0].new_id
+    assert len(store.add_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_forget_deletes_all_versions_in_lineage():
+    store = FakeVectorStore()
+    weaver = Weaver(vector_store=store, embed_fn=fake_embed)
+
+    first = await weaver.execute(
+        JudgeResult(operations=[
+            Operation(type=OperationType.ADD, content="work / company = Google"),
+        ]),
+        JudgeDomain.PROFILE,
+        "user-1",
+    )
+    updated = await weaver.execute(
+        JudgeResult(operations=[
+            Operation(
+                type=OperationType.UPDATE,
+                embedding_id=first.executed[0].new_id,
+                content="work / company = OpenAI",
+            ),
+        ]),
+        JudgeDomain.PROFILE,
+        "user-1",
+    )
+
+    deleted = await weaver.execute(
+        JudgeResult(operations=[
+            Operation(type=OperationType.DELETE, embedding_id=updated.executed[0].new_id),
+        ]),
+        JudgeDomain.PROFILE,
+        "user-1",
+    )
+
+    assert deleted.executed[0].status == OpStatus.SUCCESS
+    assert store.records == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add SHA-256 content hashing to vector-memory metadata and skip duplicate ADD/UPDATE writes before re-embedding
- store memory lineage metadata (`parent_memory_id`, `version`, `is_current`) and preserve prior versions by adding new current vectors on UPDATE
- forget full memory lineages on DELETE and filter superseded/forgotten memories out of judge/retrieval paths
- expand focused Weaver tests for duplicate detection, versioned updates, and lineage deletion

Fixes #166

## Tests
- `.venv/bin/python -m pytest tests/test_deterministic_memory_layer.py tests/integration/test_weaver_pipeline.py -q`
- `git diff --check`
- `.venv/bin/python -m compileall -q src/agents/judge.py src/pipelines/retrieval.py src/pipelines/weaver.py tests/test_deterministic_memory_layer.py tests/integration/test_weaver_pipeline.py`
