### PR TITLE
Record Razorpay payments in billing summary

### DIFF
--- a/src/api/routes/billing.py
+++ b/src/api/routes/billing.py
@@ -95,6 +95,10 @@ def _pro_plan_id_for_region(region: str) -> str | None:
     return settings.razorpay_pro_plan_id
 
 
+def _minor_amount(value: Any) -> int | None:
+    return int(value) if value is not None else None
+
+
 @router.get("/plans", response_model=list[PlanPublic])
 async def list_billing_plans() -> list[PlanPublic]:
     return public_plans()
@@ -160,7 +164,9 @@ async def create_razorpay_checkout(
                     "subscription_id": checkout_id,
                     "amount": int(checkout_package["price_minor_unit"]),
                     "currency": str(checkout_package.get("currency") or "INR"),
-                    "credits": int(checkout_package.get("monthly_credits") or 0),
+                    "credits": int(
+                        billing_config.PLANS["pro"].get("monthly_credits") or 0
+                    ),
                     "status": "created",
                 },
             )
@@ -251,7 +257,7 @@ async def verify_razorpay_payment(
             user_id=user_id,
             payment_id=request.razorpay_payment_id,
             subscription_id=request.razorpay_subscription_id,
-            amount=int(checkout.get("amount") or 0) or None,
+            amount=_minor_amount(checkout.get("amount")),
             currency=checkout.get("currency"),
             billing_region=checkout.get("billing_region") or request.billing_region,
         )
@@ -279,7 +285,7 @@ async def verify_razorpay_payment(
                 user_id=user_id,
                 payment_id=request.razorpay_payment_id,
                 subscription_id=request.razorpay_order_id,
-                amount=int(checkout.get("amount") or 0) or None,
+                amount=_minor_amount(checkout.get("amount")),
                 currency=checkout.get("currency"),
                 billing_region=checkout.get("billing_region") or request.billing_region,
             )
@@ -290,7 +296,7 @@ async def verify_razorpay_payment(
                 pack_id=package_id,
                 payment_id=request.razorpay_payment_id,
                 order_id=request.razorpay_order_id,
-                amount=int(checkout.get("amount") or 0) or None,
+                amount=_minor_amount(checkout.get("amount")),
                 currency=checkout.get("currency"),
                 billing_region=checkout.get("billing_region") or request.billing_region,
             )
@@ -357,7 +363,7 @@ async def razorpay_webhook(request: Request) -> dict[str, str]:
                 user_id=user_id,
                 payment_id=payment_id,
                 subscription_id=subscription_id or order_id,
-                amount=int(payment.get("amount") or 0) or None,
+                amount=_minor_amount(payment.get("amount")),
                 currency=payment.get("currency"),
                 billing_region=notes.get("billing_region"),
             )
@@ -371,7 +377,7 @@ async def razorpay_webhook(request: Request) -> dict[str, str]:
                 pack_id=package_id,
                 payment_id=payment_id,
                 order_id=order_id,
-                amount=int(payment.get("amount") or 0) or None,
+                amount=_minor_amount(payment.get("amount")),
                 currency=payment.get("currency"),
                 billing_region=notes.get("billing_region"),
             )

--- a/src/api/routes/billing.py
+++ b/src/api/routes/billing.py
@@ -158,6 +158,9 @@ async def create_razorpay_checkout(
                     "package_id": request.package_id,
                     "billing_region": billing_region,
                     "subscription_id": checkout_id,
+                    "amount": int(checkout_package["price_minor_unit"]),
+                    "currency": str(checkout_package.get("currency") or "INR"),
+                    "credits": int(checkout_package.get("monthly_credits") or 0),
                     "status": "created",
                 },
             )
@@ -248,6 +251,9 @@ async def verify_razorpay_payment(
             user_id=user_id,
             payment_id=request.razorpay_payment_id,
             subscription_id=request.razorpay_subscription_id,
+            amount=int(checkout.get("amount") or 0) or None,
+            currency=checkout.get("currency"),
+            billing_region=checkout.get("billing_region") or request.billing_region,
         )
     elif request.razorpay_order_id:
         if not verify_order_signature(
@@ -273,6 +279,9 @@ async def verify_razorpay_payment(
                 user_id=user_id,
                 payment_id=request.razorpay_payment_id,
                 subscription_id=request.razorpay_order_id,
+                amount=int(checkout.get("amount") or 0) or None,
+                currency=checkout.get("currency"),
+                billing_region=checkout.get("billing_region") or request.billing_region,
             )
         else:
             await asyncio.to_thread(
@@ -281,6 +290,9 @@ async def verify_razorpay_payment(
                 pack_id=package_id,
                 payment_id=request.razorpay_payment_id,
                 order_id=request.razorpay_order_id,
+                amount=int(checkout.get("amount") or 0) or None,
+                currency=checkout.get("currency"),
+                billing_region=checkout.get("billing_region") or request.billing_region,
             )
     else:
         raise HTTPException(status_code=400, detail="Missing Razorpay order or subscription id")
@@ -345,6 +357,9 @@ async def razorpay_webhook(request: Request) -> dict[str, str]:
                 user_id=user_id,
                 payment_id=payment_id,
                 subscription_id=subscription_id or order_id,
+                amount=int(payment.get("amount") or 0) or None,
+                currency=payment.get("currency"),
+                billing_region=notes.get("billing_region"),
             )
         elif package_id == "pro":
             logger.warning("Razorpay pro webhook missing subscription/order id: %s", event_name)
@@ -356,6 +371,9 @@ async def razorpay_webhook(request: Request) -> dict[str, str]:
                 pack_id=package_id,
                 payment_id=payment_id,
                 order_id=order_id,
+                amount=int(payment.get("amount") or 0) or None,
+                currency=payment.get("currency"),
+                billing_region=notes.get("billing_region"),
             )
         elif package_id in billing_config.TOP_UP_PACKS:
             logger.warning("Razorpay top-up webhook missing order id: %s", event_name)

--- a/src/billing/service.py
+++ b/src/billing/service.py
@@ -353,30 +353,58 @@ class BillingService:
         available_credits = int(wallet.get("available_credits") or 0)
         status = str(account.get("status") or "trialing")
         account_status = "trial" if status == "trialing" else status
-        invoices = [
-            PaymentInvoicePublic(
-                id=str(invoice.get("id") or invoice.get("razorpay_payment_id")),
-                date=invoice.get("paid_at") or invoice.get("created_at") or utc_now(),
-                amount_paise=int(
-                    invoice.get("amount_paise") or invoice.get("amount") or 0
-                ),
-                currency=str(invoice.get("currency") or plan.get("currency") or "INR"),
-                status=str(invoice.get("status") or "paid"),
-                credits=int(invoice.get("credits") or 0),
-                receipt_url=invoice.get("receipt_url"),
-                package_id=invoice.get("package_id"),
-                razorpay_payment_id=invoice.get("razorpay_payment_id"),
+        invoices = []
+        for invoice in self.store.list_payment_invoices(account["id"]):
+            raw_amount = (
+                invoice.get("amount_minor_units")
+                if invoice.get("amount_minor_units") is not None
+                else (
+                    invoice.get("amount_paise")
+                    if invoice.get("amount_paise") is not None
+                    else invoice.get("amount")
+                )
             )
-            for invoice in self.store.list_payment_invoices(account["id"])
-        ]
+            amount_minor_units = int(raw_amount or 0)
+            invoices.append(
+                PaymentInvoicePublic(
+                    id=str(invoice.get("id") or invoice.get("razorpay_payment_id")),
+                    date=invoice.get("paid_at")
+                    or invoice.get("created_at")
+                    or utc_now(),
+                    amount_minor_units=amount_minor_units,
+                    amount_paise=amount_minor_units,
+                    currency=str(
+                        invoice.get("currency") or plan.get("currency") or "INR"
+                    ),
+                    status=str(invoice.get("status") or "paid"),
+                    credits=int(invoice.get("credits") or 0),
+                    receipt_url=invoice.get("receipt_url"),
+                    package_id=invoice.get("package_id"),
+                    razorpay_payment_id=invoice.get("razorpay_payment_id"),
+                )
+            )
         last_payment_at = invoices[0].date if invoices else None
-        credits_limit = int(
-            plan.get("monthly_credits")
-            or plan.get("trial_credits")
-            or available_credits
-            or 0
+        if plan_id == "free" and plan.get("trial_credits") is not None:
+            credits_limit = int(plan.get("trial_credits") or 0)
+        elif plan.get("monthly_credits") is not None:
+            credits_limit = int(plan.get("monthly_credits") or 0)
+        else:
+            credits_limit = int(plan.get("trial_credits") or available_credits or 0)
+
+        period_start = account.get("current_period_start") or utc_now().replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
         )
-        current_usage = max(credits_limit - available_credits, 0)
+        ledger_entries = self.store.list_ledger(account["id"], limit=500)
+        current_usage = sum(
+            abs(int(entry.get("amount") or 0))
+            for entry in ledger_entries
+            if entry.get("type") == "debit"
+            and (
+                not period_start
+                or not entry.get("created_at")
+                or entry["created_at"] >= period_start
+            )
+        )
         lots = [
             CreditLotPublic(
                 id=str(lot["id"]),

--- a/src/billing/service.py
+++ b/src/billing/service.py
@@ -16,9 +16,11 @@ from src.billing.types import (
     BillingSummary,
     CreditEstimate,
     CreditLotPublic,
+    PaymentInvoicePublic,
     PlanPublic,
     ReservationResult,
     TopUpPackPublic,
+    UsageSnapshotPublic,
 )
 from src.utils import billing as billing_config
 
@@ -242,10 +244,15 @@ class BillingService:
         user_id: str,
         payment_id: str,
         subscription_id: str,
+        amount: Optional[int] = None,
+        currency: Optional[str] = None,
+        billing_region: Optional[str] = None,
+        receipt_url: Optional[str] = None,
         period_end=None,
     ) -> dict[str, Any]:
         account = self.store.ensure_account(owner_id=user_id)
         plan = billing_config.PLANS["pro"]
+        price = billing_config.plan_price("pro", billing_region)
         expires_at = period_end or (utc_now() + timedelta(days=30))
         self.store.update_account(
             account["id"],
@@ -256,14 +263,40 @@ class BillingService:
                 "current_period_end": expires_at,
             },
         )
-        return self.store.grant_credits(
+        grant = self.store.grant_credits(
             account_id=account["id"],
             amount=int(plan["monthly_credits"]),
             source="pro_monthly",
             expires_at=expires_at,
             idempotency_key=f"pro_grant:{subscription_id}:{payment_id}",
-            metadata={"payment_id": payment_id, "subscription_id": subscription_id},
+            metadata={
+                "payment_id": payment_id,
+                "subscription_id": subscription_id,
+                "billing_region": billing_config.normalize_billing_region(
+                    billing_region
+                ),
+            },
         )
+        self.store.record_payment_invoice(
+            payment_id=payment_id,
+            payload={
+                "billing_account_id": account["id"],
+                "user_id": user_id,
+                "package_id": "pro",
+                "package_type": "plan",
+                "amount_paise": int(
+                    amount if amount is not None else price["price_minor_unit"]
+                ),
+                "currency": str(currency or price.get("currency") or "INR"),
+                "credits": int(plan["monthly_credits"]),
+                "razorpay_subscription_id": subscription_id,
+                "billing_region": billing_config.normalize_billing_region(
+                    billing_region
+                ),
+                "receipt_url": receipt_url,
+            },
+        )
+        return grant
 
     def grant_topup(
         self,
@@ -272,10 +305,14 @@ class BillingService:
         pack_id: str,
         payment_id: str,
         order_id: str,
+        amount: Optional[int] = None,
+        currency: Optional[str] = None,
+        billing_region: Optional[str] = None,
+        receipt_url: Optional[str] = None,
     ) -> dict[str, Any]:
         pack = billing_config.TOP_UP_PACKS[pack_id]
         account = self.store.ensure_account(owner_id=user_id)
-        return self.store.grant_credits(
+        grant = self.store.grant_credits(
             account_id=account["id"],
             amount=int(pack["credits"]),
             source=pack_id,
@@ -287,12 +324,59 @@ class BillingService:
                 "pack_id": pack_id,
             },
         )
+        self.store.record_payment_invoice(
+            payment_id=payment_id,
+            payload={
+                "billing_account_id": account["id"],
+                "user_id": user_id,
+                "package_id": pack_id,
+                "package_type": "topup",
+                "amount_paise": int(
+                    amount if amount is not None else pack["price_paise"]
+                ),
+                "currency": str(currency or pack.get("currency") or "INR"),
+                "credits": int(pack["credits"]),
+                "razorpay_order_id": order_id,
+                "billing_region": billing_config.normalize_billing_region(
+                    billing_region
+                ),
+                "receipt_url": receipt_url,
+            },
+        )
+        return grant
 
     def get_billing_summary(self, user: Mapping[str, Any]) -> BillingSummary:
         account = self.ensure_billing_account(user)
         wallet = self.store.get_wallet(account["id"])
         plan_id = str(account.get("plan_id") or "free")
         plan = billing_config.PLANS.get(plan_id, billing_config.PLANS["free"])
+        available_credits = int(wallet.get("available_credits") or 0)
+        status = str(account.get("status") or "trialing")
+        account_status = "trial" if status == "trialing" else status
+        invoices = [
+            PaymentInvoicePublic(
+                id=str(invoice.get("id") or invoice.get("razorpay_payment_id")),
+                date=invoice.get("paid_at") or invoice.get("created_at") or utc_now(),
+                amount_paise=int(
+                    invoice.get("amount_paise") or invoice.get("amount") or 0
+                ),
+                currency=str(invoice.get("currency") or plan.get("currency") or "INR"),
+                status=str(invoice.get("status") or "paid"),
+                credits=int(invoice.get("credits") or 0),
+                receipt_url=invoice.get("receipt_url"),
+                package_id=invoice.get("package_id"),
+                razorpay_payment_id=invoice.get("razorpay_payment_id"),
+            )
+            for invoice in self.store.list_payment_invoices(account["id"])
+        ]
+        last_payment_at = invoices[0].date if invoices else None
+        credits_limit = int(
+            plan.get("monthly_credits")
+            or plan.get("trial_credits")
+            or available_credits
+            or 0
+        )
+        current_usage = max(credits_limit - available_credits, 0)
         lots = [
             CreditLotPublic(
                 id=str(lot["id"]),
@@ -308,12 +392,24 @@ class BillingService:
             owner_id=str(account.get("owner_id")),
             plan_id=plan_id,
             plan_name=str(plan.get("name") or plan_id),
-            status=str(account.get("status") or "trialing"),
+            status=status,
+            account_status=account_status,
             currency=str(plan.get("currency") or "INR"),
-            available_credits=int(wallet.get("available_credits") or 0),
+            available_credits=available_credits,
+            credit_balance=available_credits,
             reserved_credits=int(wallet.get("reserved_credits") or 0),
+            prepaid_balance_paise=int(
+                available_credits * billing_config.nominal_paise_per_credit(plan_id)
+            ),
             current_period_start=account.get("current_period_start"),
             current_period_end=account.get("current_period_end"),
+            current_month=UsageSnapshotPublic(
+                credits_used=current_usage,
+                credits_limit=credits_limit,
+            ),
+            next_invoice_paise=0,
+            last_payment_at=last_payment_at,
+            invoices=invoices,
             credit_lots=lots,
         )
 

--- a/src/billing/store.py
+++ b/src/billing/store.py
@@ -140,6 +140,13 @@ class BillingStore:
             self.payments.create_index(
                 [("razorpay_payment_id", ASCENDING)], unique=True, sparse=True
             )
+            self.payments.create_index(
+                [
+                    ("billing_account_id", ASCENDING),
+                    ("type", ASCENDING),
+                    ("paid_at", ASCENDING),
+                ]
+            )
 
             self._connected = True
             self._in_memory = False

--- a/src/billing/store.py
+++ b/src/billing/store.py
@@ -22,6 +22,7 @@ _memory_reservations: dict[str, dict[str, Any]] = {}
 _memory_usage_events: list[dict[str, Any]] = []
 _memory_checkouts: dict[str, dict[str, Any]] = {}
 _memory_payment_events: dict[str, dict[str, Any]] = {}
+_memory_payment_records: dict[str, dict[str, Any]] = {}
 
 
 class BillingStoreError(RuntimeError):
@@ -1046,6 +1047,84 @@ class BillingStore:
                 else None
             )
         return _without_id(self.payments.find_one({"id": checkout_id}))
+
+    def record_payment_invoice(
+        self,
+        *,
+        payment_id: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        if not payment_id:
+            raise ValueError("Razorpay payment id is required")
+        now = utc_now()
+        checkout_id = payload.get("razorpay_subscription_id") or payload.get(
+            "razorpay_order_id"
+        )
+        doc = {
+            "id": payment_id,
+            "type": "invoice",
+            "razorpay_payment_id": payment_id,
+            "status": "paid",
+            **payload,
+            "paid_at": payload.get("paid_at") or now,
+            "updated_at": now,
+        }
+        if self._in_memory:
+            existing = _memory_payment_records.get(payment_id)
+            if existing:
+                _memory_payment_records[payment_id] = {**existing, **doc}
+            else:
+                _memory_payment_records[payment_id] = {**doc, "created_at": now}
+            if checkout_id and checkout_id in _memory_checkouts:
+                _memory_checkouts[checkout_id]["status"] = "paid"
+                _memory_checkouts[checkout_id]["payment_id"] = payment_id
+                _memory_checkouts[checkout_id]["updated_at"] = now
+            return dict(_memory_payment_records[payment_id])
+
+        from pymongo import ReturnDocument
+
+        invoice = self.payments.find_one_and_update(
+            {"razorpay_payment_id": payment_id},
+            {"$set": doc, "$setOnInsert": {"created_at": now}},
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        if checkout_id:
+            self.payments.update_one(
+                {"id": checkout_id},
+                {
+                    "$set": {
+                        "status": "paid",
+                        "payment_id": payment_id,
+                        "updated_at": now,
+                    }
+                },
+            )
+        return _without_id(invoice) or doc
+
+    def list_payment_invoices(
+        self, account_id: str, limit: int = 20
+    ) -> list[dict[str, Any]]:
+        if self._in_memory:
+            invoices = [
+                dict(invoice)
+                for invoice in _memory_payment_records.values()
+                if invoice.get("billing_account_id") == account_id
+                and invoice.get("type") == "invoice"
+            ]
+            return sorted(
+                invoices,
+                key=lambda item: item.get("paid_at") or item.get("created_at"),
+                reverse=True,
+            )[:limit]
+        return [
+            _without_id(invoice) or {}
+            for invoice in self.payments.find(
+                {"billing_account_id": account_id, "type": "invoice"}
+            )
+            .sort("paid_at", -1)
+            .limit(limit)
+        ]
 
     def mark_payment_event(self, event_id: str, payload: dict[str, Any]) -> bool:
         if not event_id:

--- a/src/billing/types.py
+++ b/src/billing/types.py
@@ -48,6 +48,7 @@ class UsageSnapshotPublic(BaseModel):
 class PaymentInvoicePublic(BaseModel):
     id: str
     date: datetime
+    amount_minor_units: int = 0
     amount_paise: int = 0
     currency: str = "INR"
     status: Literal["paid", "pending", "failed"] = "paid"

--- a/src/billing/types.py
+++ b/src/billing/types.py
@@ -37,6 +37,26 @@ class CreditLotPublic(BaseModel):
     expires_at: Optional[datetime] = None
 
 
+class UsageSnapshotPublic(BaseModel):
+    memories_written: int = 0
+    retrievals: int = 0
+    graph_queries: int = 0
+    credits_used: int = 0
+    credits_limit: int = 0
+
+
+class PaymentInvoicePublic(BaseModel):
+    id: str
+    date: datetime
+    amount_paise: int = 0
+    currency: str = "INR"
+    status: Literal["paid", "pending", "failed"] = "paid"
+    credits: int = 0
+    receipt_url: Optional[str] = None
+    package_id: Optional[str] = None
+    razorpay_payment_id: Optional[str] = None
+
+
 class BillingSummary(BaseModel):
     billing_account_id: str
     owner_type: str = "user"
@@ -44,11 +64,18 @@ class BillingSummary(BaseModel):
     plan_id: str
     plan_name: str
     status: str
+    account_status: str = "trial"
     currency: str = "INR"
     available_credits: int = 0
+    credit_balance: int = 0
     reserved_credits: int = 0
+    prepaid_balance_paise: int = 0
     current_period_start: Optional[datetime] = None
     current_period_end: Optional[datetime] = None
+    current_month: UsageSnapshotPublic = Field(default_factory=UsageSnapshotPublic)
+    next_invoice_paise: int = 0
+    last_payment_at: Optional[datetime] = None
+    invoices: list[PaymentInvoicePublic] = Field(default_factory=list)
     credit_lots: list[CreditLotPublic] = Field(default_factory=list)
 
 

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -180,6 +180,7 @@ def test_pro_grant_is_idempotent_per_payment():
     assert len(pro_grants) == 1
     assert len(summary.invoices) == 1
     assert summary.invoices[0].id == "pay_1"
+    assert summary.invoices[0].amount_minor_units == 300
     assert summary.invoices[0].amount_paise == 300
     assert summary.invoices[0].currency == "USD"
     assert summary.invoices[0].credits == 5_000
@@ -203,10 +204,50 @@ def test_topup_grant_adds_dashboard_invoice():
     assert len(summary.invoices) == 1
     invoice = summary.invoices[0]
     assert invoice.id == "pay_topup_1"
+    assert invoice.amount_minor_units == 9_900
     assert invoice.amount_paise == 9_900
     assert invoice.currency == "INR"
     assert invoice.credits == 5_000
     assert invoice.status == "paid"
+    assert summary.current_month.credits_used == 0
+
+
+def test_zero_amount_invoice_preserves_minor_units():
+    svc = service()
+
+    svc.grant_topup(
+        user_id="user_1",
+        pack_id="topup_99",
+        payment_id="pay_zero",
+        order_id="order_zero",
+        amount=0,
+        currency="INR",
+        billing_region="IN",
+    )
+
+    summary = svc.get_billing_summary({"id": "user_1"})
+    assert summary.invoices[0].amount_minor_units == 0
+    assert summary.invoices[0].amount_paise == 0
+
+
+def test_zero_credit_paid_plan_reports_zero_credit_limit(monkeypatch):
+    svc = service()
+    account = svc.ensure_billing_account({"id": "user_1"})
+    monkeypatch.setitem(
+        billing_config.PLANS,
+        "zero_paid",
+        {
+            "name": "Zero Paid",
+            "price_paise": 0,
+            "currency": "INR",
+            "monthly_credits": 0,
+            "trial_credits": 1_000,
+        },
+    )
+    svc.store.update_account(account["id"], {"plan_id": "zero_paid", "status": "active"})
+
+    summary = svc.get_billing_summary({"id": "user_1"})
+    assert summary.current_month.credits_limit == 0
 
 
 def test_billing_config_changes_affect_estimates(monkeypatch):

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -23,6 +23,7 @@ def clear_memory_billing():
     billing_store._memory_usage_events.clear()
     billing_store._memory_checkouts.clear()
     billing_store._memory_payment_events.clear()
+    billing_store._memory_payment_records.clear()
 
 
 def service() -> BillingService:
@@ -154,12 +155,18 @@ def test_pro_grant_is_idempotent_per_payment():
         user_id="user_1",
         payment_id="pay_1",
         subscription_id="sub_1",
+        amount=300,
+        currency="USD",
+        billing_region="GLOBAL",
         period_end=utc_now() + timedelta(days=30),
     )
     svc.grant_pro_subscription(
         user_id="user_1",
         payment_id="pay_1",
         subscription_id="sub_1",
+        amount=300,
+        currency="USD",
+        billing_region="GLOBAL",
         period_end=utc_now() + timedelta(days=30),
     )
 
@@ -171,6 +178,35 @@ def test_pro_grant_is_idempotent_per_payment():
         if entry["source"] == "pro_monthly"
     ]
     assert len(pro_grants) == 1
+    assert len(summary.invoices) == 1
+    assert summary.invoices[0].id == "pay_1"
+    assert summary.invoices[0].amount_paise == 300
+    assert summary.invoices[0].currency == "USD"
+    assert summary.invoices[0].credits == 5_000
+
+
+def test_topup_grant_adds_dashboard_invoice():
+    svc = service()
+
+    svc.grant_topup(
+        user_id="user_1",
+        pack_id="topup_99",
+        payment_id="pay_topup_1",
+        order_id="order_1",
+        amount=9_900,
+        currency="INR",
+        billing_region="IN",
+    )
+
+    summary = svc.get_billing_summary({"id": "user_1"})
+    assert summary.credit_balance == 15_000
+    assert len(summary.invoices) == 1
+    invoice = summary.invoices[0]
+    assert invoice.id == "pay_topup_1"
+    assert invoice.amount_paise == 9_900
+    assert invoice.currency == "INR"
+    assert invoice.credits == 5_000
+    assert invoice.status == "paid"
 
 
 def test_billing_config_changes_affect_estimates(monkeypatch):


### PR DESCRIPTION
## Summary
- persist paid Razorpay payments as invoice records keyed by payment id
- include recent invoices and dashboard-compatible billing fields in `/api/billing/summary`
- carry checkout/webhook amount, currency, credits, and billing region into invoice rows
- add billing tests for idempotent Pro invoice creation and top-up invoice visibility

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\test_billing.py tests\api\test_billing_routes.py`